### PR TITLE
Insufficient Balance should only be visible if the user has balance lower than his input

### DIFF
--- a/app/src/components/market/sections/market_buy/market_buy.tsx
+++ b/app/src/components/market/sections/market_buy/market_buy.tsx
@@ -169,7 +169,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
   const amountError =
     maybeCollateralBalance === null
       ? null
-      : maybeCollateralBalance.isZero()
+      : maybeCollateralBalance.isZero() && amount.gt(maybeCollateralBalance)
       ? `Insufficient balance`
       : amount.gt(maybeCollateralBalance)
       ? `Value must be less than or equal to ${currentBalance} ${collateral.symbol}`

--- a/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
@@ -230,7 +230,7 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
   const collateralAmountError =
     maybeCollateralBalance === null
       ? null
-      : maybeCollateralBalance.isZero()
+      : maybeCollateralBalance.isZero() && amountToFund.gt(maybeCollateralBalance)
       ? `Insufficient balance`
       : amountToFund.gt(maybeCollateralBalance)
       ? `Value must be less than or equal to ${walletBalance} ${collateral.symbol}`
@@ -239,7 +239,7 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
   const sharesAmountError =
     maybeFundingBalance === null
       ? null
-      : maybeFundingBalance.isZero()
+      : maybeFundingBalance.isZero() && amountToRemove.gt(maybeFundingBalance)
       ? `Insufficient balance`
       : amountToRemove.gt(maybeFundingBalance)
       ? `Value must be less than or equal to ${sharesBalance} pool shares`

--- a/app/src/components/market/sections/market_sell/market_sell.tsx
+++ b/app/src/components/market/sections/market_sell/market_sell.tsx
@@ -146,11 +146,14 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
   const selectedOutcomeBalance = `${formatBigNumber(balanceItem.shares, collateral.decimals)}`
   const goBackToAddress = `/${marketMakerAddress}`
 
-  const amountError = balanceItem.shares.isZero()
-    ? `Insufficient balance`
-    : amountShares.gt(balanceItem.shares)
-    ? `Value must be less than or equal to ${selectedOutcomeBalance} shares`
-    : null
+  const amountError =
+    balanceItem.shares === null
+      ? null
+      : balanceItem.shares.isZero() && amountShares.gt(balanceItem.shares)
+      ? `Insufficient balance`
+      : amountShares.gt(balanceItem.shares)
+      ? `Value must be less than or equal to ${selectedOutcomeBalance} shares`
+      : null
 
   const isSellButtonDisabled =
     (status !== Status.Ready && status !== Status.Error) || amountShares.isZero() || amountError !== null


### PR DESCRIPTION
Closes #734 

Added some improvements how the message errors are validated 



I uploaded some images of how it looks

With 0 balance and some amount:
![Screenshot_20200702_141140](https://user-images.githubusercontent.com/1144028/86390454-76932280-bc6e-11ea-8b3b-ccc8c3bb3720.png)

With 0 balance and 0 amount:
![Screenshot_20200702_141132](https://user-images.githubusercontent.com/1144028/86390458-77c44f80-bc6e-11ea-9c13-92e8b472f06d.png)

With some balance, and the amount is greater than the balance:
![Screenshot_20200702_141028](https://user-images.githubusercontent.com/1144028/86390459-785ce600-bc6e-11ea-959e-9db2fdb0974d.png)

With some balance and 0 amount:
![Screenshot_20200702_140955](https://user-images.githubusercontent.com/1144028/86390466-798e1300-bc6e-11ea-9d31-14338b91f7ec.png)