### PR TITLE
Add Open Market Count to Categories

### DIFF
--- a/app/src/components/common/form/dropdown/index.tsx
+++ b/app/src/components/common/form/dropdown/index.tsx
@@ -125,6 +125,7 @@ const DropdownButton = styled.div`
 
 const CurrentItem = styled.div`
   align-items: center;
+  justify-content: space-between;
   color: ${props => props.theme.dropdown.buttonColor};
   display: flex;
   flex-grow: 1;
@@ -224,12 +225,19 @@ const Items = styled.div<{
   ${props => props.showScrollbar && DropdownScrollbarCSS}
 `
 
+const SecondaryText = styled.div`
+  color: #757575;
+  width: 33%;
+  text-align: right;
+`
+
 Items.defaultProps = {
   dropdownVariant: DropdownVariant.pill,
 }
 
 const Item = styled.div<{ active: boolean; dropdownVariant?: DropdownVariant }>`
   align-items: center;
+  justify-content: space-between;
   background-color: ${props =>
     props.active
       ? props.dropdownVariant === DropdownVariant.card
@@ -253,6 +261,9 @@ const Item = styled.div<{ active: boolean; dropdownVariant?: DropdownVariant }>`
       props.dropdownVariant === DropdownVariant.card
         ? '#F8F9FC'
         : props.theme.dropdown.dropdownItems.item.backgroundColorHover};
+    div {
+      color: #39474f;
+    }
   }
 `
 
@@ -262,6 +273,7 @@ const ChevronWrapper = styled.div`
 
 export interface DropdownItemProps {
   content: React.ReactNode | string
+  secondaryText?: React.ReactNode | string
   onClick?: () => void
 }
 
@@ -299,8 +311,8 @@ export const Dropdown: React.FC<Props> = props => {
     return itemIndex
   }
 
-  const getItemContent = (itemIndex: number): any => {
-    return items[getValidItemIndex(itemIndex)].content
+  const getItem = (itemIndex: number): any => {
+    return items[getValidItemIndex(itemIndex)]
   }
 
   const [currentItemIndex, setCurrentItemIndex] = useState<number>(currentItem)
@@ -324,6 +336,8 @@ export const Dropdown: React.FC<Props> = props => {
     }
   }, [isOpen])
 
+  const activeItem = getItem(currentItemIndex)
+
   return (
     <>
       <Wrapper
@@ -339,7 +353,8 @@ export const Dropdown: React.FC<Props> = props => {
       >
         <DropdownButton>
           <CurrentItem className="currentItem">
-            {placeholder && !isDirty ? placeholder : getItemContent(currentItemIndex)}
+            {placeholder && !isDirty ? placeholder : activeItem.content}
+            {!!activeItem.secondaryText && <SecondaryText>{activeItem.secondaryText}</SecondaryText>}
           </CurrentItem>
           <ChevronWrapper>
             <ChevronDown />
@@ -372,6 +387,7 @@ export const Dropdown: React.FC<Props> = props => {
                   }
                 >
                   {item.content}
+                  {!!item.secondaryText && <SecondaryText>{item.secondaryText}</SecondaryText>}
                 </Item>
               )
             })}

--- a/app/src/components/market/sections/market_list/market_home.tsx
+++ b/app/src/components/market/sections/market_list/market_home.tsx
@@ -293,7 +293,7 @@ export const MarketHome: React.FC<Props> = (props: Props) => {
   const filterItems: Array<DropdownItemProps> = filters.map((item, index) => {
     return {
       content: <CustomDropdownItem>{item.title}</CustomDropdownItem>,
-      secondaryText: index == 0 && counts.open > 0 && counts.open.toString(),
+      secondaryText: index === 0 && counts.open > 0 && counts.open.toString(),
       onClick: item.onClick,
     }
   })

--- a/app/src/components/market/sections/market_list/market_home.tsx
+++ b/app/src/components/market/sections/market_list/market_home.tsx
@@ -195,6 +195,9 @@ export const MarketHome: React.FC<Props> = (props: Props) => {
   } = props
   const [state, setState] = useState<MarketStates>(MarketStates.open)
   const [category, setCategory] = useState('All')
+  const [counts, setCounts] = useState({
+    open: 0,
+  })
   const [title, setTitle] = useState('')
   const [sortBy, setSortBy] = useState<Maybe<MarketsSortCriteria>>(props.currentFilter.sortBy)
   const [sortByDirection, setSortByDirection] = useState<'asc' | 'desc'>(props.currentFilter.sortByDirection)
@@ -287,9 +290,10 @@ export const MarketHome: React.FC<Props> = (props: Props) => {
     }
   })
 
-  const filterItems: Array<DropdownItemProps> = filters.map(item => {
+  const filterItems: Array<DropdownItemProps> = filters.map((item, index) => {
     return {
       content: <CustomDropdownItem>{item.title}</CustomDropdownItem>,
+      secondaryText: index == 0 && counts.open > 0 && counts.open.toString(),
       onClick: item.onClick,
     }
   })
@@ -306,8 +310,10 @@ export const MarketHome: React.FC<Props> = (props: Props) => {
           ...categories.data.map((item: CategoryDataItem) => {
             return {
               content: <CustomDropdownItem>{item.id}</CustomDropdownItem>,
+
               onClick: () => {
                 setCategory(item.id)
+                setCounts({ open: item.numOpenConditions })
               },
             }
           }),


### PR DESCRIPTION
Looks like theres no solid way to get a count for "All categories" but I was able to add counts for open markets when a user chooses specific categories.