### PR TITLE
If user clicks on wallet balance fill the inputfield with 2 decimals number instead of 18

### DIFF
--- a/app/src/components/common/form/big_number_input/index.tsx
+++ b/app/src/components/common/form/big_number_input/index.tsx
@@ -3,6 +3,8 @@ import { BigNumber } from 'ethers/utils'
 import React, { ChangeEvent, InputHTMLAttributes, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 
+import { getLogger } from '../../../../util/logger'
+
 const Input = styled.input`
   ::-webkit-inner-spin-button,
   ::-webkit-outer-spin-button {
@@ -33,8 +35,11 @@ type Props = OverrideProperties<
     onChange: (value: BigNumberInputReturn) => void
     step?: BigNumber
     value: Maybe<BigNumber>
+    valueToDisplay?: string
   }
 >
+
+const logger = getLogger('BigNumberInput')
 
 export const BigNumberInput: React.FC<Props> = props => {
   const {
@@ -46,6 +51,7 @@ export const BigNumberInput: React.FC<Props> = props => {
     placeholder = '0.00',
     step,
     value,
+    valueToDisplay = '',
     ...restProps
   } = props
 
@@ -86,6 +92,8 @@ export const BigNumberInput: React.FC<Props> = props => {
 
   const currentStep = step && ethers.utils.formatUnits(step, decimals)
 
+  logger.log(`Value to display: "${valueToDisplay}"`, `Value used in the background: "${currentValue}"`)
+
   return (
     <Input
       autoComplete="off"
@@ -97,7 +105,7 @@ export const BigNumberInput: React.FC<Props> = props => {
       ref={inputRef}
       step={currentStep}
       type="number"
-      value={currentValue}
+      value={valueToDisplay || currentValue}
       {...restProps}
     />
   )

--- a/app/src/components/market/sections/market_buy/market_buy.tsx
+++ b/app/src/components/market/sections/market_buy/market_buy.tsx
@@ -68,6 +68,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
   const [status, setStatus] = useState<Status>(Status.Ready)
   const [outcomeIndex, setOutcomeIndex] = useState<number>(0)
   const [amount, setAmount] = useState<BigNumber>(new BigNumber(0))
+  const [amountToDisplay, setAmountToDisplay] = useState<string>('')
   const [message, setMessage] = useState<string>('')
   const [isModalTransactionResultOpen, setIsModalTransactionResultOpen] = useState(false)
   const [tweet, setTweet] = useState('')
@@ -217,7 +218,10 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
               data-multiline={true}
               data-place="right"
               data-tip={`Spend your total ${collateral.symbol} balance on the selected outcome.`}
-              onClick={() => setAmount(collateralBalance)}
+              onClick={() => {
+                setAmount(collateralBalance)
+                setAmountToDisplay(currentBalance)
+              }}
               symbol={collateral.symbol}
               value={currentBalance}
             />
@@ -227,8 +231,12 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
                 <BigNumberInput
                   decimals={collateral.decimals}
                   name="amount"
-                  onChange={(e: BigNumberInputReturn) => setAmount(e.value)}
+                  onChange={(e: BigNumberInputReturn) => {
+                    setAmount(e.value)
+                    setAmountToDisplay('')
+                  }}
                   value={amount > new BigNumber(0) ? amount : null}
+                  valueToDisplay={amountToDisplay}
                 />
               }
               symbol={collateral.symbol}

--- a/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
@@ -86,7 +86,9 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
   const { allowance, unlock } = useCpkAllowance(signer, collateral.address)
 
   const [amountToFund, setAmountToFund] = useState<BigNumber>(new BigNumber(0))
+  const [amountToFundDisplay, setAmountToFundDisplay] = useState<string>('')
   const [amountToRemove, setAmountToRemove] = useState<BigNumber>(new BigNumber(0))
+  const [amountToRemoveDisplay, setAmountToRemoveDisplay] = useState<string>('')
   const [status, setStatus] = useState<Status>(Status.Ready)
   const [modalTitle, setModalTitle] = useState<string>('')
   const [message, setMessage] = useState<string>('')
@@ -289,7 +291,10 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
             {activeTab === Tabs.deposit && (
               <>
                 <WalletBalance
-                  onClick={() => setAmountToFund(collateralBalance)}
+                  onClick={() => {
+                    setAmountToFund(collateralBalance)
+                    setAmountToFundDisplay(walletBalance)
+                  }}
                   symbol={collateral.symbol}
                   value={walletBalance}
                 />
@@ -298,8 +303,12 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
                     <BigNumberInput
                       decimals={collateral.decimals}
                       name="amountToFund"
-                      onChange={(e: BigNumberInputReturn) => setAmountToFund(e.value)}
+                      onChange={(e: BigNumberInputReturn) => {
+                        setAmountToFund(e.value)
+                        setAmountToFundDisplay('')
+                      }}
                       value={amountToFund}
+                      valueToDisplay={amountToFundDisplay}
                     />
                   }
                   symbol={collateral.symbol}
@@ -310,7 +319,10 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
             {activeTab === Tabs.withdraw && (
               <>
                 <WalletBalance
-                  onClick={() => setAmountToRemove(fundingBalance)}
+                  onClick={() => {
+                    setAmountToRemove(fundingBalance)
+                    setAmountToRemoveDisplay(sharesBalance)
+                  }}
                   symbol="Shares"
                   text="My Pool Tokens"
                   value={sharesBalance}
@@ -320,8 +332,12 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
                     <BigNumberInput
                       decimals={collateral.decimals}
                       name="amountToRemove"
-                      onChange={(e: BigNumberInputReturn) => setAmountToRemove(e.value)}
+                      onChange={(e: BigNumberInputReturn) => {
+                        setAmountToRemove(e.value)
+                        setAmountToRemoveDisplay('')
+                      }}
                       value={amountToRemove}
+                      valueToDisplay={amountToRemoveDisplay}
                     />
                   }
                   symbol="Shares"

--- a/app/src/components/market/sections/market_sell/market_sell.tsx
+++ b/app/src/components/market/sections/market_sell/market_sell.tsx
@@ -59,6 +59,7 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
   const [outcomeIndex, setOutcomeIndex] = useState<number>(defaultOutcomeIndex)
   const [balanceItem, setBalanceItem] = useState<BalanceItem>(balances[outcomeIndex])
   const [amountShares, setAmountShares] = useState<BigNumber>(new BigNumber(0))
+  const [amountSharesToDisplay, setAmountSharesToDisplay] = useState<string>('')
   const [message, setMessage] = useState<string>('')
   const [isModalTransactionResultOpen, setIsModalTransactionResultOpen] = useState(false)
 
@@ -187,7 +188,10 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
               data-multiline={true}
               data-place="right"
               data-tip={`Sell all of the selected outcome's shares.`}
-              onClick={() => setAmountShares(balanceItem.shares)}
+              onClick={() => {
+                setAmountShares(balanceItem.shares)
+                setAmountSharesToDisplay(selectedOutcomeBalance)
+              }}
               symbol="Shares"
               value={selectedOutcomeBalance}
             />
@@ -197,8 +201,12 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
                 <BigNumberInput
                   decimals={collateral.decimals}
                   name="amount"
-                  onChange={(e: BigNumberInputReturn) => setAmountShares(e.value)}
+                  onChange={(e: BigNumberInputReturn) => {
+                    setAmountShares(e.value)
+                    setAmountSharesToDisplay('')
+                  }}
                   value={amountShares > new BigNumber(0) ? amountShares : null}
+                  valueToDisplay={amountSharesToDisplay}
                 />
               }
               symbol={'Shares'}


### PR DESCRIPTION
Closes #772 

Now, If you click in the wallet balance object, the Inputfield should truncate the number but internally we use the number with all the decimals

![Peek 03-07-2020 11-51](https://user-images.githubusercontent.com/1144028/86479964-81f45580-bd23-11ea-846c-586b7d6a7b27.gif)

The solution  affects the action of buy, sell, deposit and withdraw