### PR TITLE
Use Gnosis' dedicated WalletConnect bridge

### DIFF
--- a/app/src/util/connectors.ts
+++ b/app/src/util/connectors.ts
@@ -11,7 +11,7 @@ const MetaMask = new InjectedConnector({
 
 const WalletConnect = new WalletConnectConnector({
   api: WalletConnectApi,
-  bridge: 'https://bridge.walletconnect.org',
+  bridge: 'https://safe-walletconnect.gnosis.io',
   supportedNetworkURLs,
   defaultNetwork: 1,
 })


### PR DESCRIPTION
> some people reported that they’re having problems with Omen/WalletConnect, after a brief look it looks like Omen uses default wc bridge (bridge.walletconnect.org), it’s used by many projects and looks like sometimes it struggles to handle all the load. 

This replaces the default bridge with one deployed by Gnosis Devops team.