### PR TITLE
Use fee from market instead of constant

### DIFF
--- a/app/src/components/market/common/transaction_details_row/index.tsx
+++ b/app/src/components/market/common/transaction_details_row/index.tsx
@@ -30,10 +30,12 @@ const Title = styled.h4`
 
 const Value = styled.p<{ state: ValueStates; emphasizeValue?: boolean }>`
   color: ${props =>
+    (!props.emphasizeValue && props.state === ValueStates.success && props.theme.colors.textColorLightish) ||
     (props.state === ValueStates.success && props.theme.colors.green) ||
     (props.state === ValueStates.error && props.theme.colors.error) ||
     (props.state === ValueStates.important && props.theme.colors.textColorDark) ||
     props.theme.colors.textColorLightish};
+    };
   font-weight: ${props => (props.emphasizeValue ? '500' : '400')};
   margin: 0;
 `

--- a/app/src/components/market/sections/market_buy/market_buy.tsx
+++ b/app/src/components/market/sections/market_buy/market_buy.tsx
@@ -6,7 +6,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom'
 import ReactTooltip from 'react-tooltip'
 import styled from 'styled-components'
 
-import { DOCUMENT_VALIDITY_RULES, MARKET_FEE } from '../../../../common/constants'
+import { DOCUMENT_VALIDITY_RULES } from '../../../../common/constants'
 import {
   useAsyncDerivedValue,
   useCollateralBalance,
@@ -62,7 +62,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
 
   const { buildMarketMaker } = useContracts(context)
   const { marketMakerData } = props
-  const { address: marketMakerAddress, balances, collateral, question } = marketMakerData
+  const { address: marketMakerAddress, balances, collateral, fee, question } = marketMakerData
   const marketMaker = useMemo(() => buildMarketMaker(marketMakerAddress), [buildMarketMaker, marketMakerAddress])
 
   const [status, setStatus] = useState<Status>(Status.Ready)
@@ -156,7 +156,8 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
   const showSetAllowance =
     allowanceFinished || hasZeroAllowance === Ternary.True || hasEnoughAllowance === Ternary.False
 
-  const feePaid = mulBN(debouncedAmount, MARKET_FEE / 100)
+  const feePaid = mulBN(debouncedAmount, Number(formatBigNumber(fee, collateral.decimals)))
+
   const baseCost = debouncedAmount.sub(feePaid)
   const potentialProfit = tradedShares.isZero() ? new BigNumber(0) : tradedShares.sub(amount)
 

--- a/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState } from 'react'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
 import styled from 'styled-components'
 
-import { DOCUMENT_FAQ, MARKET_FEE } from '../../../../common/constants'
+import { DOCUMENT_FAQ } from '../../../../common/constants'
 import {
   useCollateralBalance,
   useConnectedWeb3Context,
@@ -72,7 +72,15 @@ const logger = getLogger('Market::Fund')
 
 const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
   const { marketMakerData } = props
-  const { address: marketMakerAddress, balances, collateral, question, totalPoolShares, userEarnings } = marketMakerData
+  const {
+    address: marketMakerAddress,
+    balances,
+    collateral,
+    fee,
+    question,
+    totalPoolShares,
+    userEarnings,
+  } = marketMakerData
 
   const context = useConnectedWeb3Context()
   const { account, library: provider } = context
@@ -95,6 +103,11 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
   const [isModalTransactionResultOpen, setIsModalTransactionResultOpen] = useState(false)
 
   const [activeTab, setActiveTab] = useState(Tabs.deposit)
+
+  const feeFormatted = useMemo(() => `${formatBigNumber(fee.mul(Math.pow(10, 2)), collateral.decimals)}%`, [
+    fee,
+    collateral.decimals,
+  ])
 
   const hasEnoughAllowance = RemoteData.mapToTernary(allowance, allowance => allowance.gte(amountToFund))
   const hasZeroAllowance = RemoteData.mapToTernary(allowance, allowance => allowance.isZero())
@@ -350,10 +363,10 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
             {activeTab === Tabs.deposit && (
               <TransactionDetailsCard>
                 <TransactionDetailsRow
-                  emphasizeValue={MARKET_FEE > 0}
+                  emphasizeValue={fee.gt(0)}
                   state={ValueStates.success}
                   title={'Earn Trading Fee'}
-                  value={`${MARKET_FEE}%`}
+                  value={feeFormatted}
                 />
                 <TransactionDetailsLine />
                 <TransactionDetailsRow

--- a/app/src/components/market/sections/market_sell/market_sell.tsx
+++ b/app/src/components/market/sections/market_sell/market_sell.tsx
@@ -4,7 +4,6 @@ import { RouteComponentProps, withRouter } from 'react-router-dom'
 import ReactTooltip from 'react-tooltip'
 import styled from 'styled-components'
 
-import { MARKET_FEE } from '../../../../common/constants'
 import { useAsyncDerivedValue, useConnectedWeb3Context, useContracts } from '../../../../hooks'
 import { CPKService, MarketMakerService } from '../../../../services'
 import { getLogger } from '../../../../util/logger'
@@ -42,7 +41,7 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
   const { buildMarketMaker, conditionalTokens } = useContracts(context)
 
   const { marketMakerData } = props
-  const { address: marketMakerAddress, balances, collateral, question } = marketMakerData
+  const { address: marketMakerAddress, balances, collateral, fee, question } = marketMakerData
 
   let defaultOutcomeIndex = 0
   for (let i = 0; i < balances.length; i++) {
@@ -63,7 +62,7 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
   const [message, setMessage] = useState<string>('')
   const [isModalTransactionResultOpen, setIsModalTransactionResultOpen] = useState(false)
 
-  const marketFeeWithTwoDecimals = MARKET_FEE / Math.pow(10, 2)
+  const marketFeeWithTwoDecimals = Number(formatBigNumber(fee, collateral.decimals))
 
   const calcSellAmount = useMemo(
     () => async (


### PR DESCRIPTION
Closes #896 

If we are showing markets with differents fees, then for fee calculations we must use the current fee and not the one used for newly created markets.