### PR TITLE
Dust amount remains after user sold/bought outcome tokens

### DIFF
--- a/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
@@ -160,7 +160,7 @@ const FundingAndFeeStep = (props: Props) => {
   const amountError =
     maybeCollateralBalance === null
       ? null
-      : maybeCollateralBalance.isZero()
+      : maybeCollateralBalance.isZero() && funding.gt(maybeCollateralBalance)
       ? `Insufficient balance`
       : funding.gt(maybeCollateralBalance)
       ? `Value must be less than or equal to ${collateralBalanceFormatted} ${collateral.symbol}`

--- a/app/src/components/market/sections/market_sell/market_sell.tsx
+++ b/app/src/components/market/sections/market_sell/market_sell.tsx
@@ -76,7 +76,8 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
       })
 
       const amountToSell = calcSellAmountInCollateral(
-        amountShares.mul(99999).div(100000), // because of some precision error, we need to multiply the amount by 0.99999
+        // If the transaction incur in some precision error, we need to multiply the amount by some factor, for example  amountShares.mul(99999).div(100000) , bigger the factor, less dust
+        amountShares,
         holdingsOfSoldOutcome,
         holdingsOfOtherOutcomes,
         marketFeeWithTwoDecimals,
@@ -102,6 +103,7 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
 
       const probabilities = pricesAfterTrade.map(priceAfterTrade => priceAfterTrade * 100)
 
+      logger.log(`Amount to sell ${amountToSell}`)
       return [probabilities, costFee, amountToSell, potentialValue]
     },
     [outcomeIndex, balances, marketFeeWithTwoDecimals],

--- a/app/src/services/market_maker.ts
+++ b/app/src/services/market_maker.ts
@@ -128,13 +128,15 @@ class MarketMakerService {
     const collateralTokenAddress = await this.getCollateralToken()
 
     const balances = []
-    logger.debug(`Outcomes quantity ${outcomeQuantity}`)
+    logger.debug(`Balance information :: Outcomes quantity ${outcomeQuantity}`)
     for (let i = 0; i < outcomeQuantity; i++) {
       const collectionId = await this.conditionalTokens.getCollectionIdForOutcome(conditionId, 1 << i)
-      logger.debug(`Collection ID for outcome index ${i} and condition id ${conditionId} : ${collectionId}`)
+      logger.debug(
+        `Balance information :: Collection ID for outcome index ${i} and condition id ${conditionId} : ${collectionId}`,
+      )
       const positionIdForCollectionId = await this.conditionalTokens.getPositionId(collateralTokenAddress, collectionId)
       const balance = await this.conditionalTokens.getBalanceOf(ownerAddress, positionIdForCollectionId)
-      logger.debug(`Balance ${balance.toString()}`)
+      logger.debug(`Balance information :: Balance ${balance.toString()}`)
       balances.push(balance)
     }
 


### PR DESCRIPTION
Closes #886 
Closes #901 

A piece of code that was used to solve a precision problem was removed.
Something to keep into account, if the user enter some amount without all the decimals, can incur in some dust in the shares. 
Perhaps it is possible to alert the user about any dust that remains in the market, especially when the amount entered is done manually and not by clicking on the max link.

![test](https://user-images.githubusercontent.com/1144028/86866390-40f39c80-c0a7-11ea-9697-203ec7a022fe.gif)


