### PR TITLE
Add max deposit functionality to fund market widget

### DIFF
--- a/app/src/components/common/form/textfield_custom_symbol/index.tsx
+++ b/app/src/components/common/form/textfield_custom_symbol/index.tsx
@@ -112,7 +112,7 @@ const MaxButton = styled.span`
 `
 
 export const TextfieldCustomSymbol = (props: Props) => {
-  const { disabled, formField, shouldDisplayMaxButton, onClickMaxButton, symbol, ...restProps } = props
+  const { disabled, formField, onClickMaxButton, shouldDisplayMaxButton, symbol, ...restProps } = props
 
   // eslint-disable-next-line no-warning-comments
   //TODO: use a input[text] instead of passing a <Textfield />

--- a/app/src/components/common/form/textfield_custom_symbol/index.tsx
+++ b/app/src/components/common/form/textfield_custom_symbol/index.tsx
@@ -7,6 +7,7 @@ interface Props {
   disabled?: boolean
   formField: any
   symbol: any
+  maxButton?: boolean
 }
 
 const FieldWrapper = styled.div`
@@ -85,6 +86,7 @@ const Symbol = styled.span`
   font-weight: 500;
   line-height: 1.2;
   text-align: right;
+  margin-right: 20px;
 
   .disabled &,
   .disabled:hover &,
@@ -96,8 +98,19 @@ const Symbol = styled.span`
   }
 `
 
+const MaxButton = styled.span`
+  padding-left: 20px;
+  border-left: 1px solid ${props => props.theme.textfield.borderColor};
+  color: ${props => props.theme.textfield.color}
+  white-space: nowrap;
+  height: ${props => props.theme.textfield.height};
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+`
+
 export const TextfieldCustomSymbol = (props: Props) => {
-  const { disabled, formField, symbol, ...restProps } = props
+  const { disabled, formField, maxButton, symbol, ...restProps } = props
 
   // eslint-disable-next-line no-warning-comments
   //TODO: use a input[text] instead of passing a <Textfield />
@@ -105,6 +118,7 @@ export const TextfieldCustomSymbol = (props: Props) => {
     <FieldWrapper className={disabled ? 'disabled' : ''} {...restProps}>
       {React.cloneElement(formField, { disabled: disabled })}
       <Symbol>{symbol}</Symbol>
+      {maxButton && <MaxButton>Max</MaxButton>}
     </FieldWrapper>
   )
 }

--- a/app/src/components/common/form/textfield_custom_symbol/index.tsx
+++ b/app/src/components/common/form/textfield_custom_symbol/index.tsx
@@ -8,6 +8,7 @@ interface Props {
   formField: any
   symbol: any
   maxButton?: boolean
+  onMax?: () => void
 }
 
 const FieldWrapper = styled.div`
@@ -110,7 +111,7 @@ const MaxButton = styled.span`
 `
 
 export const TextfieldCustomSymbol = (props: Props) => {
-  const { disabled, formField, maxButton, symbol, ...restProps } = props
+  const { disabled, formField, maxButton, onMax, symbol, ...restProps } = props
 
   // eslint-disable-next-line no-warning-comments
   //TODO: use a input[text] instead of passing a <Textfield />
@@ -118,7 +119,7 @@ export const TextfieldCustomSymbol = (props: Props) => {
     <FieldWrapper className={disabled ? 'disabled' : ''} {...restProps}>
       {React.cloneElement(formField, { disabled: disabled })}
       <Symbol>{symbol}</Symbol>
-      {maxButton && <MaxButton>Max</MaxButton>}
+      {maxButton && <MaxButton onClick={onMax}>Max</MaxButton>}
     </FieldWrapper>
   )
 }

--- a/app/src/components/common/form/textfield_custom_symbol/index.tsx
+++ b/app/src/components/common/form/textfield_custom_symbol/index.tsx
@@ -7,8 +7,8 @@ interface Props {
   disabled?: boolean
   formField: any
   symbol: any
-  maxButton?: boolean
-  onMax?: () => void
+  shouldDisplayMaxButton?: boolean
+  onClickMaxButton?: () => void
 }
 
 const FieldWrapper = styled.div`
@@ -108,10 +108,11 @@ const MaxButton = styled.span`
   font-size: 14px;
   display: flex;
   align-items: center;
+  cursor: pointer;
 `
 
 export const TextfieldCustomSymbol = (props: Props) => {
-  const { disabled, formField, maxButton, onMax, symbol, ...restProps } = props
+  const { disabled, formField, shouldDisplayMaxButton, onClickMaxButton, symbol, ...restProps } = props
 
   // eslint-disable-next-line no-warning-comments
   //TODO: use a input[text] instead of passing a <Textfield />
@@ -119,7 +120,7 @@ export const TextfieldCustomSymbol = (props: Props) => {
     <FieldWrapper className={disabled ? 'disabled' : ''} {...restProps}>
       {React.cloneElement(formField, { disabled: disabled })}
       <Symbol>{symbol}</Symbol>
-      {maxButton && <MaxButton onClick={onMax}>Max</MaxButton>}
+      {shouldDisplayMaxButton && <MaxButton onClick={onClickMaxButton}>Max</MaxButton>}
     </FieldWrapper>
   )
 }

--- a/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
@@ -182,9 +182,11 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
   const signer = useMemo(() => provider.getSigner(), [provider])
 
   const { back, handleChange, handleCollateralChange, marketCreationStatus, resetTradingFee, submit, values } = props
-  const { arbitrator, category, collateral, funding, outcomes, question, resolution, spread } = values
+  const { arbitrator, category, collateral, outcomes, question, resolution, spread } = values
+  const { funding } = values
 
   const [allowanceFinished, setAllowanceFinished] = useState(false)
+  const [amount, setAmount] = useState<BigNumber>(funding)
   const { allowance, unlock } = useCpkAllowance(signer, collateral.address)
 
   const hasEnoughAllowance = RemoteData.mapToTernary(allowance, allowance => allowance.gte(funding))
@@ -262,10 +264,9 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
     setFee(spread)
   }, [spread])
 
-  const onMax = () => {
-    const input: HTMLInputElement = Array.from(document.getElementsByName('funding'))[0] as HTMLInputElement
-    console.log(input.value)
-    input.value = formatBigNumber(collateralBalance, collateral.decimals)
+  const handleAmountChange = (event: BigNumberInputReturn) => {
+    setAmount(event.value)
+    handleChange(event)
   }
 
   return (
@@ -345,10 +346,15 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
             )}
             <TextfieldCustomPlaceholder
               formField={
-                <BigNumberInput decimals={collateral.decimals} name="funding" onChange={handleChange} value={funding} />
+                <BigNumberInput
+                  decimals={collateral.decimals}
+                  name="funding"
+                  onChange={handleAmountChange}
+                  value={amount}
+                />
               }
               maxButton={true}
-              onMax={onMax}
+              onMax={() => setAmount(collateralBalance)}
               symbol={collateral.symbol}
             />
             {customFee && (

--- a/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
@@ -287,8 +287,8 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
   const onClickMaxButton = async () => {
     setAmount(collateralBalance)
     handleChange({
-        name: 'funding',
-        value: collateralBalance
+      name: 'funding',
+      value: collateralBalance,
     })
   }
 
@@ -368,7 +368,7 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
               </CurrenciesWrapper>
             )}
             <TextfieldCustomPlaceholder
-                formField={
+              formField={
                 <BigNumberInput
                   decimals={collateral.decimals}
                   name="funding"
@@ -376,9 +376,9 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
                   value={amount}
                 />
               }
-                shouldDisplayMaxButton={true}
-                onClickMaxButton={onClickMaxButton}
-                symbol={collateral.symbol}
+              shouldDisplayMaxButton={true}
+              onClickMaxButton={onClickMaxButton}
+              symbol={collateral.symbol}
             />
             {customFee && (
               <CustomFeeWrapper>

--- a/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
@@ -376,8 +376,8 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
                   value={amount}
                 />
               }
-              shouldDisplayMaxButton={true}
               onClickMaxButton={onClickMaxButton}
+              shouldDisplayMaxButton={true}
               symbol={collateral.symbol}
             />
             {customFee && (

--- a/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
@@ -262,6 +262,12 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
     setFee(spread)
   }, [spread])
 
+  const onMax = () => {
+    const input: HTMLInputElement = Array.from(document.getElementsByName('funding'))[0] as HTMLInputElement
+    console.log(input.value)
+    input.value = formatBigNumber(collateralBalance, collateral.decimals)
+  }
+
   return (
     <>
       <CreateCardTop>
@@ -342,6 +348,7 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
                 <BigNumberInput decimals={collateral.decimals} name="funding" onChange={handleChange} value={funding} />
               }
               maxButton={true}
+              onMax={onMax}
               symbol={collateral.symbol}
             />
             {customFee && (

--- a/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
@@ -341,6 +341,7 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
               formField={
                 <BigNumberInput decimals={collateral.decimals} name="funding" onChange={handleChange} value={funding} />
               }
+              maxButton={true}
               symbol={collateral.symbol}
             />
             {customFee && (

--- a/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
@@ -284,16 +284,12 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
     handleChange(event)
   }
 
-  const onMax = async () => {
-    const input: HTMLInputElement = Array.from(document.getElementsByName('funding'))[0] as HTMLInputElement
-    input.addEventListener('change', e => {
-      const event: ChangeEvent<HTMLInputElement> = e as any
-      handleChange(event)
-    })
+  const onClickMaxButton = async () => {
     setAmount(collateralBalance)
-    setTimeout(() => {
-      input.dispatchEvent(new CustomEvent('change'))
-    }, 1000)
+    handleChange({
+        name: 'funding',
+        value: collateralBalance
+    })
   }
 
   return (
@@ -372,7 +368,7 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
               </CurrenciesWrapper>
             )}
             <TextfieldCustomPlaceholder
-              formField={
+                formField={
                 <BigNumberInput
                   decimals={collateral.decimals}
                   name="funding"
@@ -380,9 +376,9 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
                   value={amount}
                 />
               }
-              maxButton={true}
-              onMax={onMax}
-              symbol={collateral.symbol}
+                shouldDisplayMaxButton={true}
+                onClickMaxButton={onClickMaxButton}
+                symbol={collateral.symbol}
             />
             {customFee && (
               <CustomFeeWrapper>

--- a/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
@@ -182,12 +182,12 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
   const signer = useMemo(() => provider.getSigner(), [provider])
 
   const { back, handleChange, handleCollateralChange, marketCreationStatus, resetTradingFee, submit, values } = props
-  const { arbitrator, category, collateral, outcomes, question, resolution, spread } = values
-  const { funding } = values
+  const { arbitrator, category, collateral, funding, outcomes, question, resolution, spread } = values
 
   const [allowanceFinished, setAllowanceFinished] = useState(false)
-  const [amount, setAmount] = useState<BigNumber>(funding)
   const { allowance, unlock } = useCpkAllowance(signer, collateral.address)
+
+  const [amount, setAmount] = useState<BigNumber>(funding)
 
   const hasEnoughAllowance = RemoteData.mapToTernary(allowance, allowance => allowance.gte(funding))
   const hasZeroAllowance = RemoteData.mapToTernary(allowance, allowance => allowance.isZero())
@@ -213,6 +213,8 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
     distributionHint.length > 0
       ? calcInitialFundingSendAmounts(funding, distributionHint)
       : outcomes.map(() => new BigNumber(0))
+
+  console.log(funding)
 
   const amountError =
     maybeCollateralBalance === null
@@ -267,6 +269,18 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
   const handleAmountChange = (event: BigNumberInputReturn) => {
     setAmount(event.value)
     handleChange(event)
+  }
+
+  const onMax = async () => {
+    const input: HTMLInputElement = Array.from(document.getElementsByName('funding'))[0] as HTMLInputElement
+    input.addEventListener('change', e => {
+      const event: ChangeEvent<HTMLInputElement> = e as any
+      handleChange(event)
+    })
+    setAmount(collateralBalance)
+    setTimeout(() => {
+      input.dispatchEvent(new CustomEvent('change'))
+    }, 1000)
   }
 
   return (
@@ -354,7 +368,7 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
                 />
               }
               maxButton={true}
-              onMax={() => setAmount(collateralBalance)}
+              onMax={onMax}
               symbol={collateral.symbol}
             />
             {customFee && (

--- a/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
@@ -214,8 +214,6 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
       ? calcInitialFundingSendAmounts(funding, distributionHint)
       : outcomes.map(() => new BigNumber(0))
 
-  console.log(funding)
-
   const amountError =
     maybeCollateralBalance === null
       ? null


### PR DESCRIPTION
Intends to close https://github.com/protofire/omen-exchange/issues/1001

I'm trying to get this setup, but having some trouble figuring out a way that will work. On clicking the max button, we want to set the value of the input to the `collateralBalance` and trigger the `onchange` event so that `handleChange` will run. The problem seems to be that manually triggering the `onchange` event processes the event with the string value of the input instead of the `BigNumberInputReturn`. I'm not sure of a way to get past this without modifying the `handleChange` function significantly.

Note: The `handleAmount` and `onMax` functions are a bit of a mess as a result of experimentation, ideally we would call the `handleChange` function directly `onchange`.