### PR TITLE
Prevent incorrect decimal value when switching collateral

### DIFF
--- a/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
@@ -199,15 +199,23 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
   const hasEnoughAllowance = RemoteData.mapToTernary(allowance, allowance => allowance.gte(funding))
   const hasZeroAllowance = RemoteData.mapToTernary(allowance, allowance => allowance.isZero())
 
-  React.useEffect(() => {
+  useEffect(() => {
     dispatch(fetchAccountBalance(account, provider, collateral))
   }, [dispatch, account, provider, collateral])
 
+  const [collateralBalance, setCollateralBalance] = useState<BigNumber>(Zero)
+  const [collateralBalanceFormatted, setCollateralBalanceFormatted] = useState<string>(
+    formatBigNumber(collateralBalance, collateral.decimals),
+  )
   const maybeCollateralBalance = useCollateralBalance(collateral, context)
-  const collateralBalance = maybeCollateralBalance || Zero
-  const resolutionDate = resolution && formatDate(resolution)
 
-  const collateralBalanceFormatted = formatBigNumber(collateralBalance, collateral.decimals)
+  useEffect(() => {
+    setCollateralBalance(maybeCollateralBalance || Zero)
+    setCollateralBalanceFormatted(formatBigNumber(maybeCollateralBalance || Zero, collateral.decimals))
+    // eslint-disable-next-line
+  }, [maybeCollateralBalance])
+
+  const resolutionDate = resolution && formatDate(resolution)
 
   const [customFee, setCustomFee] = useState(false)
   const [exceedsMaxFee, setExceedsMaxFee] = useState<boolean>(false)


### PR DESCRIPTION
Closes https://github.com/protofire/omen-exchange/issues/1000

Note: The solution I took was to only update `collateralBalance` and `collateralBalanceFormatted` when `maybeCollateralBalance` is updated, and not when `collateral.decimals` is updated. This required withholding `collateral.decimals` from the `useEffect` dependencies array. If anyone knows a cleaner way of doing this, it's welcome.