### PR TITLE
Chart 2 digits

### DIFF
--- a/app/src/components/market/common/history_chart/chart.tsx
+++ b/app/src/components/market/common/history_chart/chart.tsx
@@ -141,7 +141,7 @@ const timestampToDate = (timestamp: number, value: string) => {
   return ts.format('MMM D')
 }
 
-const toPercent = (decimal: number, fixed = 0) => {
+const toPercent = (decimal: number, fixed = 2) => {
   return `${(decimal * 100).toFixed(fixed)}%`
 }
 

--- a/app/src/components/market/common/history_chart/chart.tsx
+++ b/app/src/components/market/common/history_chart/chart.tsx
@@ -201,7 +201,7 @@ export const HistoryChart: React.FC<Props> = ({ holdingSeries, onChange, options
       <ResponsiveContainer height={300} width="100%">
         <AreaChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }} stackOffset="expand">
           <XAxis dataKey="date" />
-          <YAxis orientation="right" tickFormatter={toPercent} />
+          <YAxis domain={['auto', 'auto']} orientation="right" tickFormatter={toPercent} />
           <Tooltip content={renderTooltipContent} />
 
           {outcomes


### PR DESCRIPTION
Related to #1055, it seems like the best solution is to simply chart 2 digits after the comma.

Video preview : https://d.pr/v/6BS2RW

Changing the default of "fixed" to 2 instead of 0 seems to be better, because of : 

`<YAxis orientation="right" tickFormatter={**toPercent**} />`

This function seems to be used strictly within the charting : 

![Screenshot 2020-08-24 at 16 20 55](https://user-images.githubusercontent.com/3656623/91049391-d03c1b80-e625-11ea-841a-db1361e70351.png)
