### PR TITLE
Use CJS modules to quell Jest

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -111,6 +111,12 @@
       "pre-push": "yarn lint:check"
     }
   },
+  "jest": {
+    "transformIgnorePatterns": [
+      "[/\\\\]node_modules[/\\\\](?!(contract-proxy-kit))[/\\\\].*\\.(js|jsx|mjs|cjs|ts|tsx)$",
+      "^.+\\.module\\.(css|sass|scss)$"
+    ]
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/app/src/hooks/useCpk.tsx
+++ b/app/src/hooks/useCpk.tsx
@@ -1,5 +1,5 @@
 import CPK from 'contract-proxy-kit'
-import EthersAdapter from 'contract-proxy-kit/lib/esm/ethLibAdapters/EthersAdapter'
+import EthersAdapter from 'contract-proxy-kit/lib/cjs/ethLibAdapters/EthersAdapter'
 import { ethers } from 'ethers'
 import { useEffect, useState } from 'react'
 import { useWeb3Context } from 'web3-react'

--- a/app/src/hooks/useCpk.tsx
+++ b/app/src/hooks/useCpk.tsx
@@ -1,5 +1,5 @@
-import CPK from 'contract-proxy-kit'
-import EthersAdapter from 'contract-proxy-kit/lib/cjs/ethLibAdapters/EthersAdapter'
+import CPK from 'contract-proxy-kit/lib/esm'
+import EthersAdapter from 'contract-proxy-kit/lib/esm/ethLibAdapters/EthersAdapter'
 import { ethers } from 'ethers'
 import { useEffect, useState } from 'react'
 import { useWeb3Context } from 'web3-react'

--- a/app/src/services/cpk.ts
+++ b/app/src/services/cpk.ts
@@ -1,5 +1,5 @@
 import CPK from 'contract-proxy-kit'
-import EthersAdapter from 'contract-proxy-kit/lib/esm/ethLibAdapters/EthersAdapter'
+import EthersAdapter from 'contract-proxy-kit/lib/cjs/ethLibAdapters/EthersAdapter'
 import { ethers } from 'ethers'
 import { TransactionReceipt, Web3Provider } from 'ethers/providers'
 import { BigNumber } from 'ethers/utils'

--- a/app/src/services/cpk.ts
+++ b/app/src/services/cpk.ts
@@ -1,5 +1,5 @@
-import CPK from 'contract-proxy-kit'
-import EthersAdapter from 'contract-proxy-kit/lib/cjs/ethLibAdapters/EthersAdapter'
+import CPK from 'contract-proxy-kit/lib/esm'
+import EthersAdapter from 'contract-proxy-kit/lib/esm/ethLibAdapters/EthersAdapter'
 import { ethers } from 'ethers'
 import { TransactionReceipt, Web3Provider } from 'ethers/providers'
 import { BigNumber } from 'ethers/utils'


### PR DESCRIPTION
So this is one way to allow the tests to pass again, by changing the imports back to CJS. Jest prefers CJS modules when running tests, and by default does not process anything in `node_modules` with Babel or anything. I'm not sure how it works with the other parts of the CRA toolchain, since clearly building the app with webpack follows different compilation rules.

This is actually another subtlety to look out for with this PR. I had changed the imports to use ES6 modules because webpack actually looks for the `module` property in `package.json` and prefers ES6 modules, and since CPK defines that property, webpack actually resolves to the ES6 import path when importing `contract-proxy-kit`. Changing the provider import to use the ES6 version makes the imports more consistent on the webpack side, as well as enables more consistent code generation. In fact, ideally, since this frontend is in TypeScript, I would have opted for importing the TS paths (so everything under `src` instead of `lib/esm` or `lib/cjs`).

However, since Jest looks for CJS modules by default, when resolving paths, it doesn't do what webpack does, but instead uses the `main` property of the `package.json` in order to find a CJS module to resolve to. Since it doesn't understand the ES6 module import syntax, the test runner errors with the ES6 imports, but webpack is able to cope with both ES6 and CJS modules, and ES6 is really preferred on the webpack side because of tree-shaking.

Anyway, TL;DR: made tests pass again, but at a small cost to code compilation quality.

P.S. I've been trying to figure out the right config for getting both ES6 imports (or even TS imports) on the webpack side, but sticking to CJS on the Jest side, but it's been weird. There's no Babel config in this repo, which seems to be a prerequisite for setting up `transformIgnorePatterns` in the Jest configuration, according to some comments I found [here](https://github.com/facebook/jest/issues/6229#issuecomment-403539460). I think maybe CRA hides the Babel config in order to streamline development...?