### PR TITLE
Fix redeem errors caused by numerical issues

### DIFF
--- a/app/src/components/market/common/outcome_table/index.tsx
+++ b/app/src/components/market/common/outcome_table/index.tsx
@@ -1,3 +1,4 @@
+import Big from 'big.js'
 import { BigNumber } from 'ethers/utils'
 import React, { useCallback } from 'react'
 import styled, { css } from 'styled-components'
@@ -17,7 +18,7 @@ interface Props {
   displayRadioSelection?: boolean
   outcomeHandleChange?: (e: number) => void
   outcomeSelected?: number
-  payouts?: Maybe<number[]>
+  payouts?: Maybe<Big[]>
   probabilities: number[]
   newShares?: Maybe<BigNumber[]>
   withWinningOutcome?: boolean
@@ -131,12 +132,12 @@ export const OutcomeTable = (props: Props) => {
 
   const renderTableRow = (balanceItem: BalanceItem, outcomeIndex: number) => {
     const { currentPrice, outcomeName, payout, shares } = balanceItem
-    const currentPriceFormatted = withWinningOutcome ? payout : Number(currentPrice).toFixed(2)
-    const probability = withWinningOutcome ? payout * 100 : probabilities[outcomeIndex]
+    const currentPriceFormatted = withWinningOutcome ? payout.toFixed(2) : Number(currentPrice).toFixed(2)
+    const probability = withWinningOutcome ? Number(payout.mul(100).toString()) : probabilities[outcomeIndex]
     const newPrice = (probabilities[outcomeIndex] / 100).toFixed(2)
-    const formattedPayout = formatBigNumber(mulBN(shares, payout), collateral.decimals)
+    const formattedPayout = formatBigNumber(mulBN(shares, Number(payout.toString())), collateral.decimals)
     const formattedShares = formatBigNumber(shares, collateral.decimals)
-    const isWinningOutcome = payouts && payouts[outcomeIndex] > 0
+    const isWinningOutcome = payouts && payouts[outcomeIndex] && payouts[outcomeIndex].gt(0)
     const formattedNewShares = newShares ? formatBigNumber(newShares[outcomeIndex], collateral.decimals) : null
 
     return (

--- a/app/src/components/market/common/winning_badge/index.tsx
+++ b/app/src/components/market/common/winning_badge/index.tsx
@@ -1,3 +1,4 @@
+import Big from 'big.js'
 import React, { DOMAttributes } from 'react'
 import styled from 'styled-components'
 
@@ -29,7 +30,7 @@ const Text = styled.div<{ outcomeIndex: number }>`
 interface Props extends DOMAttributes<HTMLDivElement> {
   index: number
   outcomeName?: string
-  payouts: Maybe<number[]>
+  payouts: Maybe<Big[]>
 }
 
 export const WinningBadge: React.FC<Props> = props => {
@@ -40,7 +41,7 @@ export const WinningBadge: React.FC<Props> = props => {
       <Wrapper outcomeIndex={index} {...restProps}>
         <IconDragonBall />
         <Text outcomeIndex={index}>
-          {payouts[index] < 1 ? `${payouts[index] * 100}% ` : ''} {outcomeName}
+          {payouts[index].lt(1) ? `${payouts[index].mul(100).toFixed(2)}% ` : ''} {outcomeName}
         </Text>
       </Wrapper>
     )

--- a/app/src/components/market/sections/market_profile/market_status/closed.tsx
+++ b/app/src/components/market/sections/market_profile/market_status/closed.tsx
@@ -41,7 +41,7 @@ interface Props extends RouteComponentProps<Record<string, string | undefined>> 
 
 const logger = getLogger('Market::ClosedMarketDetail')
 
-const computeEarnedCollateral = (payouts: Maybe<number[]>, balances: BigNumber[]): Maybe<BigNumber> => {
+const computeEarnedCollateral = (payouts: Maybe<Big[]>, balances: BigNumber[]): Maybe<BigNumber> => {
   if (!payouts) {
     return null
   }
@@ -167,15 +167,22 @@ const Wrapper = (props: Props) => {
   }
 
   const hasWinningOutcomes = earnedCollateral && earnedCollateral.gt(0)
-  const winnersOutcomes = payouts ? payouts.filter(payout => payout > 0).length : 0
+  const winnersOutcomes = payouts ? payouts.filter(payout => payout.gt(0)).length : 0
   const userWinnersOutcomes = payouts
-    ? payouts.filter((payout, index) => balances[index].shares.gt(0) && payout > 0).length
+    ? payouts.filter((payout, index) => balances[index].shares.gt(0) && payout.gt(0)).length
     : 0
   const userWinnerShares = payouts
-    ? balances.reduce((acc, balance, index) => (payouts[index] > 0 ? acc.add(balance.shares) : acc), new BigNumber(0))
+    ? balances.reduce((acc, balance, index) => (payouts[index].gt(0) ? acc.add(balance.shares) : acc), new BigNumber(0))
     : new BigNumber(0)
   const EPS = 0.01
-  const allPayoutsEqual = payouts ? payouts.every(payout => Math.abs(payout - 1 / payouts.length) <= EPS) : false
+  const allPayoutsEqual = payouts
+    ? payouts.every(payout =>
+        payout
+          .sub(1 / payouts.length)
+          .abs()
+          .lte(EPS),
+      )
+    : false
 
   const buySellButtons = (
     <>

--- a/app/src/components/market/sections/market_profile/market_status/closed.tsx
+++ b/app/src/components/market/sections/market_profile/market_status/closed.tsx
@@ -50,10 +50,9 @@ const computeEarnedCollateral = (payouts: Maybe<Big[]>, balances: BigNumber[]): 
   Big.RM = 0
 
   const earnedCollateralPerOutcome = balances.map((balance, index) => new Big(balance.toString()).mul(payouts[index]))
+  const earnedCollateral = earnedCollateralPerOutcome.reduce((a, b) => a.add(b.toFixed(0)), bigNumberify(0))
 
-  const earnedCollateral = earnedCollateralPerOutcome.reduce((a, b) => a.add(b))
-
-  return bigNumberify(earnedCollateral.toFixed(0))
+  return earnedCollateral
 }
 
 const Wrapper = (props: Props) => {

--- a/app/src/hooks/useBlockchainMarketMakerData.tsx
+++ b/app/src/hooks/useBlockchainMarketMakerData.tsx
@@ -1,3 +1,4 @@
+import Big from 'big.js'
 import { BigNumber } from 'ethers/utils'
 import { useCallback, useEffect, useState } from 'react'
 
@@ -17,7 +18,7 @@ const getBalances = (
   outcomes: string[],
   marketMakerShares: BigNumber[],
   userShares: BigNumber[],
-  payouts: Maybe<number[]>,
+  payouts: Maybe<Big[]>,
 ): BalanceItem[] => {
   const actualPrices = MarketMakerService.getActualPrice(marketMakerShares)
 
@@ -34,7 +35,7 @@ const getBalances = (
       currentPrice,
       shares,
       holdings,
-      payout: payouts ? payouts[index] : 0,
+      payout: payouts ? payouts[index] : new Big(0),
     }
   })
 

--- a/app/src/hooks/useGraphMarketMakerData.tsx
+++ b/app/src/hooks/useGraphMarketMakerData.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@apollo/react-hooks'
+import Big from 'big.js'
 import { BigNumber, bigNumberify } from 'ethers/utils'
 import gql from 'graphql-tag'
 import { useState } from 'react'
@@ -101,7 +102,7 @@ export type GraphMarketMakerData = {
   lastActiveDay: number
   dailyVolume: BigNumber
   conditionId: string
-  payouts: Maybe<number[]>
+  payouts: Maybe<Big[]>
   fee: BigNumber
   question: Question
   scaledLiquidityParameter: number
@@ -129,7 +130,7 @@ const wrangleResponse = (data: GraphResponseFixedProductMarketMaker, networkId: 
     lastActiveDay: Number(data.lastActiveDay),
     dailyVolume: bigNumberify(data.runningDailyVolume),
     conditionId: data.condition.id,
-    payouts: data.condition.payouts ? data.condition.payouts.map(Number) : null,
+    payouts: data.condition.payouts ? data.condition.payouts.map(payout => new Big(payout)) : null,
     fee: bigNumberify(data.fee),
     scaledLiquidityParameter: parseFloat(data.scaledLiquidityParameter),
     runningDailyVolumeByHour: data.runningDailyVolumeByHour,

--- a/app/src/services/oracle.ts
+++ b/app/src/services/oracle.ts
@@ -1,3 +1,4 @@
+import Big from 'big.js'
 import { Contract, Wallet, ethers, utils } from 'ethers'
 import { TransactionReceipt } from 'ethers/providers'
 import { BigNumber } from 'ethers/utils'
@@ -53,28 +54,25 @@ export class OracleService {
     return oracleInterface.functions.resolve.encode([questionId, questionTemplateId, questionRaw, numOutcomes])
   }
 
-  static getPayouts = (templateId: number, realitioAnswer: string, numOutcomes: number): number[] => {
-    let payouts: number[]
+  static getPayouts = (templateId: number, realitioAnswer: string, numOutcomes: number): Big[] => {
+    let payouts: Big[]
     if (realitioAnswer === '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff') {
-      payouts = [...Array(numOutcomes)].map(() => 1)
+      payouts = [...Array(numOutcomes)].map(() => new Big(1))
     } else {
       const answer = new BigNumber(realitioAnswer).toNumber()
 
       if (templateId === 0 || templateId === 2) {
-        payouts = [...Array(numOutcomes)].map(() => 0)
-        payouts[answer] = 1
+        payouts = [...Array(numOutcomes)].map(() => new Big(1))
+        payouts[answer] = new Big(1)
       } else if (templateId === 5 || templateId === 6) {
-        payouts = [0, 0]
-
-        payouts[0] = 4 - answer
-        payouts[1] = answer
+        payouts = [new Big(4 - answer), new Big(answer)]
       } else {
         throw new Error(`Unsupported template id: '${templateId}'`)
       }
     }
 
-    const totalPayouts = payouts.reduce((a, b) => a + b)
+    const totalPayouts = payouts.reduce((a, b) => a.add(b))
 
-    return payouts.map(payout => payout / totalPayouts)
+    return payouts.map(payout => payout.div(totalPayouts))
   }
 }

--- a/app/src/util/types.ts
+++ b/app/src/util/types.ts
@@ -1,3 +1,4 @@
+import Big from 'big.js'
 import { Block } from 'ethers/providers'
 import { BigNumber } from 'ethers/utils'
 
@@ -16,7 +17,7 @@ export interface BalanceItem {
   probability: number
   currentPrice: number
   shares: BigNumber
-  payout: number
+  payout: Big
   holdings: BigNumber
 }
 
@@ -203,7 +204,7 @@ export interface MarketMakerData {
   collateralVolume: BigNumber
   marketMakerFunding: BigNumber
   marketMakerUserFunding: BigNumber
-  payouts: Maybe<number[]>
+  payouts: Maybe<Big[]>
   question: Question
   totalEarnings: BigNumber
   totalPoolShares: BigNumber


### PR DESCRIPTION
Basically, the redeeming batch also calculates how much will be redeemed and forwards that amount which goes to the proxy back to the owner account. Unfortunately, that amount might also be wrong because of the way that the calculation adds up all the redeemed amounts before truncating occurs, when in reality, the contract truncates the payouts before adding them. You can see this off-by-one effect in [this successful transaction](https://rinkeby.etherscan.io/tx/0x646c050b04fee63fa4019311270d508f0610f6b00149d1bb98149a6e28e17be5) (look in the DAI transfers), which went through because I had other rounded stuff that was off before due to a previous truncated import of payouts from a conversion to a float, causing me to retain DAI dust in my proxy.

@pimato Dunno which issue tracks this, so if you could link it here, would be appreciated.