### PR TITLE
fix: bottom margin for SetAllowance component

### DIFF
--- a/app/src/components/market/common/set_allowance/index.tsx
+++ b/app/src/components/market/common/set_allowance/index.tsx
@@ -4,7 +4,9 @@ import styled from 'styled-components'
 import { Token } from '../../../../util/types'
 import { ToggleTokenLock, ToggleTokenLockProps } from '../toggle_token_lock'
 
-const Wrapper = styled.div``
+const Wrapper = styled.div<{ marginBottom?: boolean }>`
+  margin-bottom: ${props => (props.marginBottom ? `20px` : '0')};
+`
 
 const Title = styled.h2`
   color: ${props => props.theme.colors.textColorDarker};
@@ -34,6 +36,7 @@ const Description = styled.p`
 export type SetAllowanceProps = DOMAttributes<HTMLDivElement> &
   ToggleTokenLockProps & {
     collateral: Token
+    marginBottom?: boolean
   }
 
 export const SetAllowance: React.FC<SetAllowanceProps> = (props: SetAllowanceProps) => {

--- a/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
@@ -416,6 +416,7 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
             collateral={collateral}
             finished={allowanceFinished && RemoteData.is.success(allowance)}
             loading={RemoteData.is.asking(allowance)}
+            marginBottom
             onUnlock={unlockCollateral}
           />
         )}


### PR DESCRIPTION
Update margin for the set allowance component on the create market page.

From:

![Screen Shot 2020-10-15 at 11 51 45 am](https://user-images.githubusercontent.com/72715177/96105040-4de51f00-0f25-11eb-9e0f-93b7cfaa4f3d.png)

To:

![Screen Shot 2020-10-15 at 11 51 05 am](https://user-images.githubusercontent.com/72715177/96105049-5178a600-0f25-11eb-8edc-c9c5bb664960.png)
