### PR TITLE
Update "Profit" to "Revenue"

### DIFF
--- a/app/src/components/market/sections/market_sell/market_sell.tsx
+++ b/app/src/components/market/sections/market_sell/market_sell.tsx
@@ -245,7 +245,7 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
             <TransactionDetailsRow
               emphasizeValue={potentialValue ? potentialValue.gt(0) : false}
               state={ValueStates.success}
-              title={'Profit'}
+              title={'Revenue'}
               value={
                 potentialValue
                   ? `${formatNumber(formatBigNumber(potentialValue, collateral.decimals, 2))} ${collateral.symbol}`


### PR DESCRIPTION
Using "profit" here is misleading and can lead to a very bad experience for the user. "Profit" implies the net result from your trade, meaning that if you bought at X, you sell at Y and your revenue is (Y-X). If you are selling at a loss, because you bought the odds disfavorably, then profit would be negative. In fact seeing the word "profit" might lead someone to think that they can still turn a profit, encourage them to sell it and they will be very very disappointed when they realize that "profit" was actually a 95% loss as that was all they would have gotten. I mean this in a totally hypothetical scenario, of course, nothing of the sorts would ever happen to me or any friend I know. 😢

So I suggest changing the wording to revenue. Or maybe "total value".