### PR TITLE
Scalar market history chart

### DIFF
--- a/app/src/components/market/common/history_chart/chart.tsx
+++ b/app/src/components/market/common/history_chart/chart.tsx
@@ -1,4 +1,4 @@
-import { bigNumberify } from 'ethers/utils'
+import { BigNumber, bigNumberify } from 'ethers/utils'
 import moment from 'moment'
 import React from 'react'
 import { Area, AreaChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
@@ -118,9 +118,13 @@ const AnEvenSmallerLittleBall = styled(OutcomeItemLittleBallOfJoyAndDifferentCol
 
 type Props = {
   holdingSeries: Maybe<HistoricData>
+  isScalar?: Maybe<boolean>
   onChange: (s: Period) => void
   options: Period[]
+  outcomeTokenMarginalPrices: string[]
   outcomes: string[]
+  scalarHigh?: Maybe<BigNumber>
+  scalarLow?: Maybe<BigNumber>
   value: Period
 }
 

--- a/app/src/components/market/common/history_chart/chart.tsx
+++ b/app/src/components/market/common/history_chart/chart.tsx
@@ -200,7 +200,7 @@ export const HistoryChart: React.FC<Props> = ({
         isScalar
           ? outcomeTokenMarginalPrices.forEach((k, i) => (outcomesPrices[k] = prices[i]))
           : outcomes.forEach((k, i) => (outcomesPrices[k] = prices[i]))
-
+        console.log(outcomesPrices)
         return { ...outcomesPrices, date: timestampToDate(h.block.timestamp, value) }
       })
 
@@ -228,7 +228,7 @@ export const HistoryChart: React.FC<Props> = ({
         <AreaChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }} stackOffset="expand">
           <XAxis dataKey="date" />
           <YAxis orientation="right" tickFormatter={isScalar ? toScaleValue : toPercent} />
-          <Tooltip content={renderTooltipContent} />
+          {/* <Tooltip content={renderTooltipContent} /> */}
 
           {outcomes
             .map((outcomeName, index) => {

--- a/app/src/components/market/common/history_chart/chart.tsx
+++ b/app/src/components/market/common/history_chart/chart.tsx
@@ -187,6 +187,26 @@ export const HistoryChart: React.FC<Props> = ({
     )} ${unit}`
   }
 
+  const renderScalarTooltipContent = (o: any) => {
+    const { label, payload } = o
+    const prediction = (
+      payload[1]?.value * ((scalarHighNumber || 0) - (scalarLowNumber || 0)) +
+      (scalarLowNumber || 0)
+    ).toFixed(0)
+    return (
+      <ChartTooltip>
+        <TooltipTitle>{label}</TooltipTitle>
+        <Legends>
+          <Legend key={`item-0`}>
+            <AnEvenSmallerLittleBall outcomeIndex={0} />
+            <strong>{`${prediction}`}</strong>
+            {`${unit}`}
+          </Legend>
+        </Legends>
+      </ChartTooltip>
+    )
+  }
+
   const outcomeArray: string[] = outcomes.length ? outcomes : ['Short', 'Long']
 
   const data =
@@ -225,7 +245,7 @@ export const HistoryChart: React.FC<Props> = ({
         <AreaChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }} stackOffset="expand">
           <XAxis dataKey="date" />
           <YAxis orientation="right" tickFormatter={isScalar ? toScaleValue : toPercent} />
-          <Tooltip content={renderTooltipContent} />
+          <Tooltip content={isScalar ? renderScalarTooltipContent : renderTooltipContent} />
 
           {outcomeArray
             .map((outcomeName, index) => {

--- a/app/src/components/market/common/history_chart/chart.tsx
+++ b/app/src/components/market/common/history_chart/chart.tsx
@@ -184,7 +184,9 @@ export const HistoryChart: React.FC<Props> = ({
   const scalarHighNumber = scalarHigh && Number(formatBigNumber(scalarHigh, 18))
 
   const toScaleValue = (decimal: number, fixed = 0) => {
-    return `${decimal * ((scalarHighNumber || 0) - (scalarLowNumber || 0)) + (scalarLowNumber || 0)} ${unit}`
+    return `${(decimal * ((scalarHighNumber || 0) - (scalarLowNumber || 0)) + (scalarLowNumber || 0)).toFixed(
+      fixed,
+    )} ${unit}`
   }
 
   const data =
@@ -195,7 +197,9 @@ export const HistoryChart: React.FC<Props> = ({
       .map(h => {
         const prices = calcPrice(h.holdings.map(bigNumberify))
         const outcomesPrices: { [outcomeName: string]: number } = {}
-        outcomes.forEach((k, i) => (outcomesPrices[k] = prices[i]))
+        isScalar
+          ? outcomeTokenMarginalPrices.forEach((k, i) => (outcomesPrices[k] = prices[i]))
+          : outcomes.forEach((k, i) => (outcomesPrices[k] = prices[i]))
 
         return { ...outcomesPrices, date: timestampToDate(h.block.timestamp, value) }
       })

--- a/app/src/components/market/common/history_chart/chart.tsx
+++ b/app/src/components/market/common/history_chart/chart.tsx
@@ -5,7 +5,7 @@ import { Area, AreaChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'rec
 import styled, { css } from 'styled-components'
 
 import { getOutcomeColor } from '../../../../theme/utils'
-import { calcPrice } from '../../../../util/tools'
+import { calcPrice, formatBigNumber } from '../../../../util/tools'
 import { HistoricData, Period } from '../../../../util/types'
 import { ButtonSelectable } from '../../../button'
 import { InlineLoading } from '../../../loading'
@@ -125,6 +125,7 @@ type Props = {
   outcomes: string[]
   scalarHigh?: Maybe<BigNumber>
   scalarLow?: Maybe<BigNumber>
+  unit: string
   value: Period
 }
 
@@ -167,7 +168,25 @@ const renderTooltipContent = (o: any) => {
   )
 }
 
-export const HistoryChart: React.FC<Props> = ({ holdingSeries, onChange, options, outcomes, value }) => {
+export const HistoryChart: React.FC<Props> = ({
+  holdingSeries,
+  isScalar,
+  onChange,
+  options,
+  outcomeTokenMarginalPrices,
+  outcomes,
+  scalarHigh,
+  scalarLow,
+  unit,
+  value,
+}) => {
+  const scalarLowNumber = scalarLow && Number(formatBigNumber(scalarLow, 18))
+  const scalarHighNumber = scalarHigh && Number(formatBigNumber(scalarHigh, 18))
+
+  const toScaleValue = (decimal: number, fixed = 0) => {
+    return `${decimal * ((scalarHighNumber || 0) - (scalarLowNumber || 0)) + (scalarLowNumber || 0)} ${unit}`
+  }
+
   const data =
     holdingSeries &&
     holdingSeries
@@ -204,7 +223,7 @@ export const HistoryChart: React.FC<Props> = ({ holdingSeries, onChange, options
       <ResponsiveContainer height={300} width="100%">
         <AreaChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }} stackOffset="expand">
           <XAxis dataKey="date" />
-          <YAxis orientation="right" tickFormatter={toPercent} />
+          <YAxis orientation="right" tickFormatter={isScalar ? toScaleValue : toPercent} />
           <Tooltip content={renderTooltipContent} />
 
           {outcomes

--- a/app/src/components/market/common/history_chart/chart.tsx
+++ b/app/src/components/market/common/history_chart/chart.tsx
@@ -121,7 +121,6 @@ type Props = {
   isScalar?: Maybe<boolean>
   onChange: (s: Period) => void
   options: Period[]
-  outcomeTokenMarginalPrices: string[]
   outcomes: string[]
   scalarHigh?: Maybe<BigNumber>
   scalarLow?: Maybe<BigNumber>
@@ -173,7 +172,6 @@ export const HistoryChart: React.FC<Props> = ({
   isScalar,
   onChange,
   options,
-  outcomeTokenMarginalPrices,
   outcomes,
   scalarHigh,
   scalarLow,
@@ -189,6 +187,8 @@ export const HistoryChart: React.FC<Props> = ({
     )} ${unit}`
   }
 
+  const outcomeArray: string[] = outcomes.length ? outcomes : ['Short', 'Long']
+
   const data =
     holdingSeries &&
     holdingSeries
@@ -197,10 +197,7 @@ export const HistoryChart: React.FC<Props> = ({
       .map(h => {
         const prices = calcPrice(h.holdings.map(bigNumberify))
         const outcomesPrices: { [outcomeName: string]: number } = {}
-        isScalar
-          ? outcomeTokenMarginalPrices.forEach((k, i) => (outcomesPrices[k] = prices[i]))
-          : outcomes.forEach((k, i) => (outcomesPrices[k] = prices[i]))
-        console.log(outcomesPrices)
+        outcomeArray.forEach((k, i) => (outcomesPrices[k] = prices[i]))
         return { ...outcomesPrices, date: timestampToDate(h.block.timestamp, value) }
       })
 
@@ -228,9 +225,9 @@ export const HistoryChart: React.FC<Props> = ({
         <AreaChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }} stackOffset="expand">
           <XAxis dataKey="date" />
           <YAxis orientation="right" tickFormatter={isScalar ? toScaleValue : toPercent} />
-          {/* <Tooltip content={renderTooltipContent} /> */}
+          <Tooltip content={renderTooltipContent} />
 
-          {outcomes
+          {outcomeArray
             .map((outcomeName, index) => {
               const color = getOutcomeColor(index)
               return (

--- a/app/src/components/market/common/history_chart/chart.tsx
+++ b/app/src/components/market/common/history_chart/chart.tsx
@@ -190,7 +190,7 @@ export const HistoryChart: React.FC<Props> = ({
   const renderScalarTooltipContent = (o: any) => {
     const { label, payload } = o
     const prediction = (
-      payload[1]?.value * ((scalarHighNumber || 0) - (scalarLowNumber || 0)) +
+      payload[0]?.value * ((scalarHighNumber || 0) - (scalarLowNumber || 0)) +
       (scalarLowNumber || 0)
     ).toFixed(0)
     return (

--- a/app/src/components/market/common/history_chart/chart.tsx
+++ b/app/src/components/market/common/history_chart/chart.tsx
@@ -192,7 +192,7 @@ export const HistoryChart: React.FC<Props> = ({
     const prediction = (
       payload[0]?.value * ((scalarHighNumber || 0) - (scalarLowNumber || 0)) +
       (scalarLowNumber || 0)
-    ).toFixed(0)
+    ).toFixed(2)
     return (
       <ChartTooltip>
         <TooltipTitle>{label}</TooltipTitle>

--- a/app/src/components/market/common/history_chart/chart.tsx
+++ b/app/src/components/market/common/history_chart/chart.tsx
@@ -244,7 +244,7 @@ export const HistoryChart: React.FC<Props> = ({
       <ResponsiveContainer height={300} width="100%">
         <AreaChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }} stackOffset="expand">
           <XAxis dataKey="date" />
-          <YAxis orientation="right" tickFormatter={isScalar ? toScaleValue : toPercent} />
+          <YAxis orientation="right" tickFormatter={isScalar ? toScaleValue : toPercent} width={80} />
           <Tooltip content={isScalar ? renderScalarTooltipContent : renderTooltipContent} />
 
           {outcomeArray

--- a/app/src/components/market/common/history_chart/index.tsx
+++ b/app/src/components/market/common/history_chart/index.tsx
@@ -79,6 +79,7 @@ type Props = {
   outcomeTokenMarginalPrices: string[]
   scalarHigh: Maybe<BigNumber>
   scalarLow: Maybe<BigNumber>
+  unit: string
 }
 
 const blocksPerAllTimePeriod = 10000
@@ -104,6 +105,7 @@ export const HistoryChartContainer: React.FC<Props> = ({
   outcomes,
   scalarHigh,
   scalarLow,
+  unit,
 }) => {
   const context = useWeb3Context()
   const { library } = context
@@ -171,6 +173,7 @@ export const HistoryChartContainer: React.FC<Props> = ({
       outcomes={outcomes}
       scalarHigh={scalarHigh}
       scalarLow={scalarLow}
+      unit={unit}
       value={period}
     />
   )

--- a/app/src/components/market/common/history_chart/index.tsx
+++ b/app/src/components/market/common/history_chart/index.tsx
@@ -4,7 +4,11 @@ import moment from 'moment'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useWeb3Context } from 'web3-react'
 
-import { EARLIEST_MAINNET_BLOCK_TO_CHECK } from '../../../../common/constants'
+import {
+  EARLIEST_MAINNET_BLOCK_TO_CHECK,
+  REALITIO_SCALAR_ADAPTER_ADDRESS,
+  REALITIO_SCALAR_ADAPTER_ADDRESS_RINKEBY,
+} from '../../../../common/constants'
 import { useMultipleQueries } from '../../../../hooks/useMultipleQueries'
 import { keys, range } from '../../../../util/tools'
 import { Period } from '../../../../util/types'
@@ -95,9 +99,14 @@ export const HistoryChartContainer: React.FC<Props> = ({
   answerFinalizedTimestamp,
   hidden,
   marketMakerAddress,
+  oracle,
+  outcomeTokenMarginalPrices,
   outcomes,
+  scalarHigh,
+  scalarLow,
 }) => {
-  const { library } = useWeb3Context()
+  const context = useWeb3Context()
+  const { library } = context
   const [latestBlockNumber, setLatestBlockNumber] = useState<Maybe<number>>(null)
   const [blocks, setBlocks] = useState<Maybe<Block[]>>(null)
   const holdingsSeries = useHoldingsHistory(marketMakerAddress, blocks)
@@ -140,12 +149,28 @@ export const HistoryChartContainer: React.FC<Props> = ({
     // eslint-disable-next-line
   }, [latestBlockNumber, library, period])
 
+  let realitioScalarAdapter
+  if (context.networkId === 1) {
+    realitioScalarAdapter = REALITIO_SCALAR_ADAPTER_ADDRESS.toLowerCase()
+  } else if (context.networkId === 4) {
+    realitioScalarAdapter = REALITIO_SCALAR_ADAPTER_ADDRESS_RINKEBY.toLowerCase()
+  }
+
+  let isScalar = false
+  if (oracle === realitioScalarAdapter) {
+    isScalar = true
+  }
+
   return hidden ? null : (
     <HistoryChart
       holdingSeries={holdingsSeries}
+      isScalar={isScalar}
       onChange={setPeriod}
       options={keys(mapPeriod)}
+      outcomeTokenMarginalPrices={outcomeTokenMarginalPrices}
       outcomes={outcomes}
+      scalarHigh={scalarHigh}
+      scalarLow={scalarLow}
       value={period}
     />
   )

--- a/app/src/components/market/common/history_chart/index.tsx
+++ b/app/src/components/market/common/history_chart/index.tsx
@@ -76,7 +76,6 @@ type Props = {
   hidden: boolean
   oracle: Maybe<string>
   outcomes: string[]
-  outcomeTokenMarginalPrices: string[]
   scalarHigh: Maybe<BigNumber>
   scalarLow: Maybe<BigNumber>
   unit: string
@@ -101,7 +100,6 @@ export const HistoryChartContainer: React.FC<Props> = ({
   hidden,
   marketMakerAddress,
   oracle,
-  outcomeTokenMarginalPrices,
   outcomes,
   scalarHigh,
   scalarLow,
@@ -169,7 +167,6 @@ export const HistoryChartContainer: React.FC<Props> = ({
       isScalar={isScalar}
       onChange={setPeriod}
       options={keys(mapPeriod)}
-      outcomeTokenMarginalPrices={outcomeTokenMarginalPrices}
       outcomes={outcomes}
       scalarHigh={scalarHigh}
       scalarLow={scalarLow}

--- a/app/src/components/market/common/history_chart/index.tsx
+++ b/app/src/components/market/common/history_chart/index.tsx
@@ -70,7 +70,11 @@ type Props = {
   answerFinalizedTimestamp: Maybe<BigNumber>
   marketMakerAddress: string
   hidden: boolean
+  oracle: Maybe<string>
   outcomes: string[]
+  outcomeTokenMarginalPrices: string[]
+  scalarHigh: Maybe<BigNumber>
+  scalarLow: Maybe<BigNumber>
 }
 
 const blocksPerAllTimePeriod = 10000

--- a/app/src/components/market/sections/market_history/market_history.tsx
+++ b/app/src/components/market/sections/market_history/market_history.tsx
@@ -31,7 +31,7 @@ const MarketHistoryWrapper: React.FC<Props> = (props: Props) => {
         outcomes={question.outcomes}
         scalarHigh={scalarHigh}
         scalarLow={scalarLow}
-        unit={question.title ? question.title.split('[')[1].split(']')[0] : ''}
+        unit={question.title && question.title.includes('[') ? question.title.split('[')[1].split(']')[0] : ''}
       />
     </>
   )

--- a/app/src/components/market/sections/market_history/market_history.tsx
+++ b/app/src/components/market/sections/market_history/market_history.tsx
@@ -20,8 +20,6 @@ const MarketHistoryWrapper: React.FC<Props> = (props: Props) => {
     scalarLow,
   } = marketMakerData
 
-  console.log(marketMakerData)
-
   return (
     <>
       <HistoryChartContainer

--- a/app/src/components/market/sections/market_history/market_history.tsx
+++ b/app/src/components/market/sections/market_history/market_history.tsx
@@ -14,7 +14,6 @@ const MarketHistoryWrapper: React.FC<Props> = (props: Props) => {
     address: marketMakerAddress,
     answerFinalizedTimestamp,
     oracle,
-    outcomeTokenMarginalPrices,
     question,
     scalarHigh,
     scalarLow,
@@ -27,7 +26,6 @@ const MarketHistoryWrapper: React.FC<Props> = (props: Props) => {
         hidden={false}
         marketMakerAddress={marketMakerAddress}
         oracle={oracle}
-        outcomeTokenMarginalPrices={outcomeTokenMarginalPrices}
         outcomes={question.outcomes}
         scalarHigh={scalarHigh}
         scalarLow={scalarLow}

--- a/app/src/components/market/sections/market_history/market_history.tsx
+++ b/app/src/components/market/sections/market_history/market_history.tsx
@@ -33,6 +33,7 @@ const MarketHistoryWrapper: React.FC<Props> = (props: Props) => {
         outcomes={question.outcomes}
         scalarHigh={scalarHigh}
         scalarLow={scalarLow}
+        unit={question.title ? question.title.split('[')[1].split(']')[0] : ''}
       />
     </>
   )

--- a/app/src/components/market/sections/market_history/market_history.tsx
+++ b/app/src/components/market/sections/market_history/market_history.tsx
@@ -10,7 +10,17 @@ interface Props extends RouteComponentProps<any> {
 
 const MarketHistoryWrapper: React.FC<Props> = (props: Props) => {
   const { marketMakerData } = props
-  const { address: marketMakerAddress, answerFinalizedTimestamp, question } = marketMakerData
+  const {
+    address: marketMakerAddress,
+    answerFinalizedTimestamp,
+    oracle,
+    outcomeTokenMarginalPrices,
+    question,
+    scalarHigh,
+    scalarLow,
+  } = marketMakerData
+
+  console.log(marketMakerData)
 
   return (
     <>
@@ -18,7 +28,11 @@ const MarketHistoryWrapper: React.FC<Props> = (props: Props) => {
         answerFinalizedTimestamp={answerFinalizedTimestamp}
         hidden={false}
         marketMakerAddress={marketMakerAddress}
+        oracle={oracle}
+        outcomeTokenMarginalPrices={outcomeTokenMarginalPrices}
         outcomes={question.outcomes}
+        scalarHigh={scalarHigh}
+        scalarLow={scalarLow}
       />
     </>
   )


### PR DESCRIPTION
Closes https://github.com/protofire/omen-exchange/issues/1403

It might be good to later migrate to a different type of chart and or design, but for the initial release I figured this is pretty good.