### PR TITLE
fix/#1455

### DIFF
--- a/app/src/components/market/sections/market_profile/market_status/open.tsx
+++ b/app/src/components/market/sections/market_profile/market_status/open.tsx
@@ -107,7 +107,8 @@ const Wrapper = (props: Props) => {
 
   useEffect(() => {
     const timeDifference = new Date(question.resolution).getTime() - new Date().getTime()
-    if (timeDifference > 0) {
+    const maxTimeDifference = 86400000
+    if (timeDifference > 0 && timeDifference < maxTimeDifference) {
       setTimeout(callAfterTimeout, timeDifference + 2000)
     }
     function callAfterTimeout() {


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/1455

This was a weird one: "Timeout values too big to fit into a signed 32-bit integer may cause overflow in FF, Safari, and Chrome, resulting in the timeout being scheduled immediately."