### PR TITLE
fix/#1456

### DIFF
--- a/app/src/hooks/useGraphMarketsFromQuestion.tsx
+++ b/app/src/hooks/useGraphMarketsFromQuestion.tsx
@@ -43,6 +43,7 @@ export const useGraphMarketsFromQuestion = (questionId: string): Result => {
 
   const { data, error, loading } = useQuery<GraphResponse>(query, {
     notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'cache-and-network',
     skip: false,
     variables: { id: questionId },
   })


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/1456 

`useQuery` returns cached results when variables are unchanged, even when mounted across different components. Updating the fetchPolicy to 'cache-and-network' will make sure we get updated values.