### PR TITLE
Update scalar slider

### DIFF
--- a/app/src/components/market/common/common_styled/index.tsx
+++ b/app/src/components/market/common/common_styled/index.tsx
@@ -282,3 +282,28 @@ export const TabsGrid = styled.div`
   grid-template-columns: 1fr 1fr;
   margin: 0 0 20px;
 `
+
+export const Circle = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-left: 8px;
+  border-radius: 50%;
+  border: 1px solid ${props => props.theme.colors.tertiary};
+  transition: border-color 0.15s linear;
+  cursor: pointer;
+  height: 18px;
+  width: 18px;
+
+  path {
+    transition: fill 0.15s linear;
+    fill: ${props => props.theme.colors.textColorLightish};
+  }
+
+  &:hover {
+    border-color: ${props => props.theme.colors.tertiaryDark};
+    path {
+      fill: ${props => props.theme.colors.textColorDark};
+    }
+  }
+`

--- a/app/src/components/market/common/market_scale/index.tsx
+++ b/app/src/components/market/common/market_scale/index.tsx
@@ -330,50 +330,16 @@ export const MarketScale: React.FC<Props> = (props: Props) => {
   }, [newPrediction, currentPrediction, lowerBoundNumber, startingPointNumber, upperBoundNumber])
 
   useEffect(() => {
-    // If taking a long position
     if (long) {
-      // If the value selected by the slider is > the new prediction number
-      if (scaleValuePrediction > newPredictionNumber) {
-        // Determine the percentage distance from the new prediction number to the upper bound
-        const positionValue = (scaleValuePrediction - newPredictionNumber) / (upperBoundNumber - newPredictionNumber)
-        // Calculate profit amount given how close it is to the upper bound, i.e. how close it is to max profit
-        const profit = positionValue * ((amountSharesNumber || 0) - (amountNumber || 0)) - (feeNumber || 0)
-        // Calculate total payout by adding profit to amount
-        setYourPayout(profit + (amountNumber || 0))
-        // Return profit amount
-        setProfitLoss(profit)
-      } else {
-        // Determine the percentage distance from the new prediction number to the lower bound as a negative value
-        const positionValue = -(scaleValuePrediction - newPredictionNumber) / (lowerBoundNumber - newPredictionNumber)
-        // Calculate loss amount given how close it is to lower bound, i.e. how close it is to max loss
-        const loss = positionValue * (amountNumber || 0) - (feeNumber || 0)
-        // Calculate total payout by adding loss to amount
-        setYourPayout((amountNumber || 0) + loss < 0 ? 0 : (amountNumber || 0) + loss)
-        // Return loss amount
-        setProfitLoss(loss < -(amountNumber || 0) ? -(amountNumber || 0) : loss)
-      }
-      // If taking a short position
+      // Calculate total payout by mulitplying shares amount by scale position
+      setYourPayout((amountSharesNumber || 0) * (Number(scaleBall?.value) / 100))
+      // Calculate profit by subtracting amount paid from payout
+      setProfitLoss((amountSharesNumber || 0) * (Number(scaleBall?.value) / 100) - (amountNumber || 0))
     } else {
-      // If the value selected by the slider is < the new prediction number
-      if (scaleValuePrediction <= newPredictionNumber) {
-        // Determine the percentage distance from the new prediction number to the lower bound
-        const positionValue = (newPredictionNumber - scaleValuePrediction) / (newPredictionNumber - lowerBoundNumber)
-        // Calculate profit amount given how close it is to the lower bound, i.e. how close it is to max profit
-        const profit = positionValue * ((amountSharesNumber || 0) - (amountNumber || 0)) - (feeNumber || 0)
-        // Calculate total payout by adding profit to amount
-        setYourPayout(profit + (amountNumber || 0))
-        // Return profit amount
-        setProfitLoss(profit)
-      } else {
-        // Determine the percentage distance from the new prediction number to the upper bound as a negative value
-        const positionValue = -(scaleValuePrediction - newPredictionNumber) / (upperBoundNumber - newPredictionNumber)
-        // Calculate loss amount given how close it is to upper bound, i.e. how close it is to max loss
-        const loss = positionValue * (amountNumber || 0) - (feeNumber || 0)
-        // Calculate total payout by adding loss to amount
-        setYourPayout((amountNumber || 0) + loss < 0 ? 0 : (amountNumber || 0) + loss)
-        // Return loss amount
-        setProfitLoss(loss < -(amountNumber || 0) ? -(amountNumber || 0) : loss)
-      }
+      // Calculate total payout by mulitplying shares amount by scale position
+      setYourPayout((amountSharesNumber || 0) * (1 - Number(scaleBall?.value) / 100))
+      // Calculate profit by subtracting amount paid from payout
+      setProfitLoss((amountSharesNumber || 0) * (1 - Number(scaleBall?.value) / 100) - (amountNumber || 0))
     }
   }, [
     scaleValuePrediction,

--- a/app/src/components/market/common/market_scale/index.tsx
+++ b/app/src/components/market/common/market_scale/index.tsx
@@ -1,9 +1,12 @@
 import { BigNumber } from 'ethers/utils'
 import React, { useEffect, useRef, useState } from 'react'
+import ReactTooltip from 'react-tooltip'
 import styled from 'styled-components'
 
 import { formatBigNumber, formatNumber } from '../../../../util/tools'
 import { Token } from '../../../../util/types'
+import { IconInfo } from '../../../common/tooltip/img/IconInfo'
+import { Circle } from '../../common/common_styled'
 
 const SCALE_HEIGHT = '20px'
 const BAR_WIDTH = '2px'
@@ -240,6 +243,8 @@ const ValueBoxSubtitle = styled.p`
   color: ${props => props.theme.colors.textColor};
   margin: 0;
   white-space: nowrap;
+  display: flex;
+  align-items: center;
 `
 
 interface Props {
@@ -350,6 +355,7 @@ export const MarketScale: React.FC<Props> = (props: Props) => {
     upperBoundNumber,
     feeNumber,
     amountSharesNumber,
+    scaleBall?.value,
   ])
 
   const activateTooltip = () => {
@@ -469,14 +475,42 @@ export const MarketScale: React.FC<Props> = (props: Props) => {
               >
                 {`${formatNumber(yourPayout.toString())} ${collateral && collateral.symbol}`}
               </ValueBoxTitle>
-              <ValueBoxSubtitle>Your Payout</ValueBoxSubtitle>
+              <ReactTooltip id="payoutTooltip" />
+              <ValueBoxSubtitle>
+                Your Payout
+                <Circle
+                  data-delay-hide={'500'}
+                  data-effect={'solid'}
+                  data-for={'payoutTooltip'}
+                  data-multiline={'true'}
+                  data-tip={`Your payout if the market resolves at ${formatNumber(
+                    scaleValuePrediction.toString(),
+                  )} ${unit}`}
+                >
+                  <IconInfo />
+                </Circle>
+              </ValueBoxSubtitle>
             </ValueBox>
             <ValueBox>
               <ValueBoxTitle positive={profitLoss > 0 ? true : profitLoss < 0 ? false : undefined}>
                 {profitLoss > 0 && '+'}
                 {`${formatNumber(profitLoss ? profitLoss.toString() : '0')} ${collateral && collateral.symbol}`}
               </ValueBoxTitle>
-              <ValueBoxSubtitle>Profit/Loss</ValueBoxSubtitle>
+              <ReactTooltip id="profitTooltip" />
+              <ValueBoxSubtitle>
+                Profit/Loss
+                <Circle
+                  data-delay-hide={'500'}
+                  data-effect={'solid'}
+                  data-for={'profitTooltip'}
+                  data-multiline={'true'}
+                  data-tip={`Your profit/loss if the market resolves at ${formatNumber(
+                    scaleValuePrediction.toString(),
+                  )} ${unit}`}
+                >
+                  <IconInfo />
+                </Circle>
+              </ValueBoxSubtitle>
             </ValueBox>
           </ValueBoxPair>
         </ValueBoxes>

--- a/app/src/components/market/common/transaction_details_row/index.tsx
+++ b/app/src/components/market/common/transaction_details_row/index.tsx
@@ -2,6 +2,7 @@ import React, { DOMAttributes } from 'react'
 import styled from 'styled-components'
 
 import { IconInfo } from '../../../common/tooltip/img/IconInfo'
+import { Circle } from '../../common/common_styled'
 
 export enum ValueStates {
   error,
@@ -30,28 +31,6 @@ const Title = styled.h4`
   opacity: 0.9;
   display: flex;
   align-items: center;
-`
-
-const Circle = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-left: 8px;
-  border-radius: 50%;
-  border: 1px solid ${props => props.theme.colors.tertiary};
-  transition: border-color 0.15s linear;
-
-  path {
-    transition: fill 0.15s linear;
-    fill: ${props => props.theme.colors.textColorLightish};
-  }
-
-  &:hover {
-    border-color: ${props => props.theme.colors.tertiaryDark};
-    path {
-      fill: ${props => props.theme.colors.textColorDark};
-    }
-  }
 `
 
 const Value = styled.p<{ state: ValueStates; emphasizeValue?: boolean }>`

--- a/app/src/components/market/sections/market_buy/scalar_market_buy.tsx
+++ b/app/src/components/market/sections/market_buy/scalar_market_buy.tsx
@@ -156,7 +156,6 @@ export const ScalarMarketBuy = (props: Props) => {
 
   const feePaid = mulBN(debouncedAmount, Number(formatBigNumber(fee, 18, 4)))
   const feePercentage = Number(formatBigNumber(fee, 18, 4)) * 100
-  const totalFee = Number(formatBigNumber(fee, 18))
 
   const baseCost = debouncedAmount.sub(feePaid)
   const potentialProfit = tradedShares.isZero() ? new BigNumber(0) : tradedShares.sub(amount)
@@ -165,9 +164,7 @@ export const ScalarMarketBuy = (props: Props) => {
   const feeFormatted = `${formatNumber(formatBigNumber(feePaid.mul(-1), collateral.decimals))} ${collateral.symbol}`
   const baseCostFormatted = `${formatNumber(formatBigNumber(baseCost, collateral.decimals))} ${collateral.symbol}`
   const potentialProfitFormatted = potentialProfit.gt(Zero)
-    ? `${formatNumber((Number(formatBigNumber(potentialProfit, collateral.decimals)) - totalFee).toString())} ${
-        collateral.symbol
-      }`
+    ? `${formatNumber(Number(formatBigNumber(potentialProfit, collateral.decimals)).toString())} ${collateral.symbol}`
     : `0.00 ${collateral.symbol}`
   const sharesTotal = formatNumber(formatBigNumber(tradedShares, collateral.decimals))
   const total = `${sharesTotal} Shares`


### PR DESCRIPTION
Closes https://github.com/protofire/omen-exchange/issues/1511

This PR changes the slider from the scalar market buy view to return payout/profit/loss values based on the redeem value at resolution, instead of returning the sell value. I've also added tooltips for clarity.