### PR TITLE
Update xDai CPK Proxy Factory

### DIFF
--- a/app/src/services/cpk.ts
+++ b/app/src/services/cpk.ts
@@ -11,6 +11,7 @@ import {
   getContractAddress,
   getTargetSafeImplementation,
   getWrapToken,
+  networkIds,
   pseudoNativeAssetAddress,
   waitForBlockToSync,
 } from '../util/networks'
@@ -169,6 +170,15 @@ class CPKService {
     return transactionReceipt
   }
 
+  getGas = async (gas: number): Promise<number> => {
+    const deployed = await this.cpk.isProxyDeployed()
+    if (deployed) {
+      return gas
+    }
+    const addProxyDeploymentGas = 500000
+    return gas + addProxyDeploymentGas
+  }
+
   buyOutcomes = async ({
     amount,
     collateral,
@@ -186,7 +196,7 @@ class CPKService {
       const txOptions: TxOptions = {}
 
       if (this.cpk.isSafeApp() || collateral.address === pseudoNativeAssetAddress) {
-        txOptions.gas = 500000
+        txOptions.gas = await this.getGas(500000)
       }
 
       let collateralAddress
@@ -284,7 +294,7 @@ class CPKService {
       const txOptions: TxOptions = {}
 
       if (this.cpk.isSafeApp() || marketData.collateral.address === pseudoNativeAssetAddress) {
-        txOptions.gas = 1200000
+        txOptions.gas = await this.getGas(1200000)
       }
 
       let collateral
@@ -464,7 +474,7 @@ class CPKService {
       const txOptions: TxOptions = {}
 
       if (this.cpk.isSafeApp() || marketData.collateral.address === pseudoNativeAssetAddress) {
-        txOptions.gas = 1500000
+        txOptions.gas = await this.getGas(1500000)
       }
 
       let collateral
@@ -623,7 +633,7 @@ class CPKService {
       const txOptions: TxOptions = {}
 
       if (this.cpk.isSafeApp()) {
-        txOptions.gas = 500000
+        txOptions.gas = await this.getGas(500000)
       }
 
       const isAlreadyApprovedForMarketMaker = await conditionalTokens.isApprovedForAll(
@@ -673,7 +683,7 @@ class CPKService {
       const txOptions: TxOptions = {}
 
       if (this.cpk.isSafeApp() || collateral.address === pseudoNativeAssetAddress) {
-        txOptions.gas = 500000
+        txOptions.gas = await this.getGas(500000)
       }
 
       let collateralAddress
@@ -770,7 +780,7 @@ class CPKService {
       const txOptions: TxOptions = {}
 
       if (this.cpk.isSafeApp()) {
-        txOptions.gas = 500000
+        txOptions.gas = await this.getGas(500000)
       }
 
       // If we are signed in as a safe we don't need to transfer
@@ -827,7 +837,7 @@ class CPKService {
       const txOptions: TxOptions = {}
 
       if (this.cpk.isSafeApp()) {
-        txOptions.gas = 500000
+        txOptions.gas = await this.getGas(500000)
       }
 
       if (!isConditionResolved) {
@@ -861,9 +871,12 @@ class CPKService {
   }
 
   proxyIsUpToDate = async (): Promise<boolean> => {
+    const network = await this.provider.getNetwork()
+    if (network.chainId === networkIds.XDAI) {
+      return true
+    }
     const deployed = await this.cpk.isProxyDeployed()
     if (deployed) {
-      const network = await this.provider.getNetwork()
       const implementation = await this.proxy.masterCopy()
       if (implementation.toLowerCase() === getTargetSafeImplementation(network.chainId).toLowerCase()) {
         return true

--- a/app/src/util/networks.ts
+++ b/app/src/util/networks.ts
@@ -221,7 +221,7 @@ const networks: { [K in NetworkId]: Network } = {
     },
     cpk: {
       masterCopyAddress: '0x6851D6fDFAfD08c0295C392436245E5bc78B0185',
-      proxyFactoryAddress: '0xfC7577774887aAE7bAcdf0Fc8ce041DA0b3200f7',
+      proxyFactoryAddress: '0x3049b84bbC3EB2C375547CAc0D77da032d3d1981',
       multiSendAddress: '0x035000FC773f4a0e39FcdeD08A46aBBDBF196fd3',
       fallbackHandlerAddress: '0x602DF5F404f86469459D5e604CDa43A2cdFb7580',
     },


### PR DESCRIPTION
Goal: Improve user experience on xDai based on feedback from @skyminert 

Removes the requirement to deploy a proxy before transacting with native xDai.

CPKFactory
`0x3049b84bbC3EB2C375547CAc0D77da032d3d1981`
https://blockscout.com/poa/xdai/address/0x3049b84bbC3EB2C375547CAc0D77da032d3d1981/contracts

Changes:
- Update `createProxyAndExecTransaction` to `payable`
- Send `msg.value` with `proxy.execTransaction`
- Enforce change of ownership after `swapOwner` (related https://github.com/gnosis/contract-proxy-kit/issues/132)

Note: Merging this PR will give all existing xDai users a new proxy address