### PR TITLE
Stack market scale value boxes on mobile

### DIFF
--- a/app/src/components/market/common/market_scale/index.tsx
+++ b/app/src/components/market/common/market_scale/index.tsx
@@ -15,7 +15,11 @@ const BALL_SIZE = '20px'
 const DOT_SIZE = '8px'
 const VALUE_BOXES_MARGIN = '12px'
 
-const ScaleWrapper = styled.div<{ borderBottom: boolean | undefined; borderTop: boolean | undefined }>`
+const ScaleWrapper = styled.div<{
+  borderBottom: boolean | undefined
+  borderTop: boolean | undefined
+  valueBoxes: boolean | undefined
+}>`
   display: flex;
   flex-direction: column;
   height: 174px;
@@ -26,6 +30,10 @@ const ScaleWrapper = styled.div<{ borderBottom: boolean | undefined; borderTop: 
   padding-right: 25px;
   position: relative;
   ${props => props.borderTop && `border-top: 1px solid ${props.theme.scale.border}; padding-top: 24px; height: 202px;`};
+
+  @media (max-width: ${props => props.theme.themeBreakPoints.md}) {
+    ${props => props.valueBoxes && 'padding-bottom: 24px; height: 278px;'}
+  }
 `
 
 const ScaleTitleWrapper = styled.div`
@@ -188,12 +196,25 @@ const ValueBoxes = styled.div`
   justify-content: space-between;
   margin-top: ${VALUE_BOXES_MARGIN};
   width: 100%;
+
+  @media (max-width: ${props => props.theme.themeBreakPoints.md}) {
+    flex-direction: column;
+    justify-content: center;
+  }
 `
 
 const ValueBoxPair = styled.div`
   width: calc(50% - ${VALUE_BOXES_MARGIN} / 2);
   display: flex;
   align-items: center;
+
+  @media (max-width: ${props => props.theme.themeBreakPoints.md}) {
+    width: calc(100% - ${VALUE_BOXES_MARGIN} / 2);
+
+    &:nth-of-type(2) {
+      margin-top: 12px;
+    }
+  }
 `
 
 const ValueBox = styled.div<{ xValue?: number }>`
@@ -477,7 +498,7 @@ export const MarketScale: React.FC<Props> = (props: Props) => {
 
   return (
     <>
-      <ScaleWrapper borderBottom={isPositionTableDisabled} borderTop={borderTop}>
+      <ScaleWrapper borderBottom={isPositionTableDisabled} borderTop={borderTop} valueBoxes={isAmountInputted}>
         <ScaleTitleWrapper>
           <ScaleTitle>
             {formatNumber(lowerBoundNumber.toString())} {unit}


### PR DESCRIPTION
Closes: https://github.com/protofire/omen-exchange/issues/1514

Before: 
<img width="368" alt="Screen Shot 2021-01-21 at 2 38 45 PM" src="https://user-images.githubusercontent.com/30579067/105421163-849e9580-5bf6-11eb-8511-7b75536de1df.png">

After: 
<img width="366" alt="Screen Shot 2021-01-21 at 2 38 28 PM" src="https://user-images.githubusercontent.com/30579067/105421185-8ec09400-5bf6-11eb-8688-e61425715c8e.png">