### PR TITLE
removed unusued rotate property which was causing error

### DIFF
--- a/app/src/components/market/common/TextToggle/index.tsx
+++ b/app/src/components/market/common/TextToggle/index.tsx
@@ -10,7 +10,7 @@ interface Props {
   onClick?: MouseEventHandler
 }
 
-const Wrapper = styled.div<{ rotate?: boolean }>`
+const Wrapper = styled.div`
   display: flex;
   align-items: center;
   cursor: pointer;
@@ -41,7 +41,7 @@ const Wrapper = styled.div<{ rotate?: boolean }>`
 export const TextToggle = (props: Props) => {
   const { alternativeLabel, isMain, mainLabel, onClick } = props
   return (
-    <Wrapper onClick={onClick} rotate={!isMain}>
+    <Wrapper onClick={onClick}>
       {isMain ? <IconMiniDown /> : <IconMiniUp />}
       <div className="text-toggle-label">{isMain ? mainLabel : alternativeLabel}</div>
     </Wrapper>


### PR DESCRIPTION
- There was this error which was happening
![Screenshot 2021-01-29 at 12 25 54](https://user-images.githubusercontent.com/33226956/106269996-994ddf80-622d-11eb-8d29-349ab0aa8dbf.png)
- I fixed it by removing the rotate property altogether since it wasn't doing anything...
- @KadenZipfel @hexyls @pRoy24  correct me if i'm wrong...