### PR TITLE
Fix/#1604

### DIFF
--- a/app/src/hooks/connectedWeb3.tsx
+++ b/app/src/hooks/connectedWeb3.tsx
@@ -64,6 +64,14 @@ export const ConnectedWeb3: React.FC = props => {
       context.setConnector('Infura')
     }
 
+    // disabled block tracker
+    const infura = connectors['Infura']
+    // @ts-expect-error ignore
+    if (infura.engine && infura.engine._blockTracker && infura.engine._blockTracker._isRunning) {
+      // @ts-expect-error ignore
+      infura.engine.stop()
+    }
+
     const checkIfReady = async () => {
       const network = await library.ready
       if (isSubscribed) setNetworkId(network.chainId)


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/1604

web3-react uses web3-provider-engine under the hood for the NetworkOnlyConnector. This automatically starts up a block tracking service that we don’t need which continues polling for blocks even if we switch connector. PR stops the block service if it is running.

