### PR TITLE
Fix scalar redeem issue

### DIFF
--- a/app/src/components/market/sections/market_profile/market_status/closed.tsx
+++ b/app/src/components/market/sections/market_profile/market_status/closed.tsx
@@ -98,7 +98,13 @@ const computeEarnedCollateral = (payouts: Maybe<Big[]>, balances: BigNumber[]): 
 }
 
 const scalarComputeEarnedCollateral = (finalAnswerPercentage: number, balances: BigNumber[]): Maybe<BigNumber> => {
-  if (!balances[0] || (balances[0].isZero() && !balances[1]) || balances[1].isZero()) return null
+  if (
+    (!balances[0] && !balances[1]) ||
+    (balances[0].isZero() && !balances[1]) ||
+    (!balances[0] && balances[1].isZero()) ||
+    (balances[0].isZero() && balances[1].isZero())
+  )
+    return null
 
   // use floor as rounding method
   Big.RM = 0


### PR DESCRIPTION
Fix of a bug that prevented earned amount on scalar markets from being calculated in certain cases