### PR TITLE
Fix failing getScalarBalances when no liquidity in closed market

### DIFF
--- a/app/src/hooks/useBlockchainMarketMakerData.tsx
+++ b/app/src/hooks/useBlockchainMarketMakerData.tsx
@@ -46,15 +46,15 @@ const getBalances = (
 }
 
 const getScalarBalances = (
-  outcomePrices: string[],
+  outcomeAmounts: string[],
   marketMakerShares: BigNumber[],
   userShares: BigNumber[],
   payouts: Maybe<Big[]>,
 ): BalanceItem[] => {
   const actualPrices = MarketMakerService.getActualPrice(marketMakerShares)
 
-  const balances: BalanceItem[] = outcomePrices.length
-    ? outcomePrices.map((price: string, index: number) => {
+  const balances: BalanceItem[] = outcomeAmounts.length
+    ? outcomeAmounts.map((price: string, index: number) => {
         const outcomeName = index === 0 ? 'short' : 'long'
         const probability = actualPrices[index] * 100
         const currentPrice = actualPrices[index]
@@ -157,12 +157,7 @@ export const useBlockchainMarketMakerData = (graphMarketMakerData: Maybe<GraphMa
 
     let balances: BalanceItem[]
     isScalar
-      ? (balances = getScalarBalances(
-          graphMarketMakerData.outcomeTokenMarginalPrices || [],
-          marketMakerShares,
-          userShares,
-          payouts,
-        ))
+      ? (balances = getScalarBalances(graphMarketMakerData.outcomeTokenAmounts, marketMakerShares, userShares, payouts))
       : (balances = getBalances(outcomes, marketMakerShares, userShares, payouts))
 
     const newMarketMakerData: MarketMakerData = {

--- a/app/src/hooks/useBlockchainMarketMakerData.tsx
+++ b/app/src/hooks/useBlockchainMarketMakerData.tsx
@@ -46,31 +46,32 @@ const getBalances = (
 }
 
 const getScalarBalances = (
-  outcomeAmounts: string[],
   marketMakerShares: BigNumber[],
   userShares: BigNumber[],
   payouts: Maybe<Big[]>,
 ): BalanceItem[] => {
   const actualPrices = MarketMakerService.getActualPrice(marketMakerShares)
 
-  const balances: BalanceItem[] = outcomeAmounts.length
-    ? outcomeAmounts.map((price: string, index: number) => {
-        const outcomeName = index === 0 ? 'short' : 'long'
-        const probability = actualPrices[index] * 100
-        const currentPrice = actualPrices[index]
-        const shares = userShares[index]
-        const holdings = marketMakerShares[index]
+  const balances: BalanceItem[] = []
 
-        return {
-          outcomeName,
-          probability,
-          currentPrice,
-          shares,
-          holdings,
-          payout: payouts ? payouts[index] : new Big(0),
-        }
-      })
-    : []
+  for (let i = 0; i < 2; i++) {
+    const outcomeName = i === 0 ? 'short' : 'long'
+    const probability = actualPrices[i] * 100
+    const currentPrice = actualPrices[i]
+    const shares = userShares[i]
+    const holdings = marketMakerShares[i]
+
+    const balance = {
+      outcomeName,
+      probability,
+      currentPrice,
+      shares,
+      holdings,
+      payout: payouts ? payouts[i] : new Big(0),
+    }
+
+    balances.push(balance)
+  }
 
   return balances
 }
@@ -157,7 +158,7 @@ export const useBlockchainMarketMakerData = (graphMarketMakerData: Maybe<GraphMa
 
     let balances: BalanceItem[]
     isScalar
-      ? (balances = getScalarBalances(graphMarketMakerData.outcomeTokenAmounts, marketMakerShares, userShares, payouts))
+      ? (balances = getScalarBalances(marketMakerShares, userShares, payouts))
       : (balances = getBalances(outcomes, marketMakerShares, userShares, payouts))
 
     const newMarketMakerData: MarketMakerData = {


### PR DESCRIPTION
Closes: https://github.com/protofire/omen-exchange/issues/1742

The problem: We were checking the amount of outcomes in a scalar market based on a data point that becomes null if liquidity is withdrawn from the market. Instead, we should assert that scalar markets always have two outcomes.

To test: Check if redeem winnings functionality exists in scalar markets with and without liquidity