### PR TITLE
move relay fee, default to unwrapping for relay

### DIFF
--- a/app/src/hooks/useCollateralBalance.tsx
+++ b/app/src/hooks/useCollateralBalance.tsx
@@ -1,7 +1,6 @@
 import { BigNumber } from 'ethers/utils'
 import { useEffect, useState } from 'react'
 
-import { RELAY_FEE } from '../common/constants'
 import { ERC20Service } from '../services'
 import { pseudoNativeAssetAddress } from '../util/networks'
 import { Token } from '../util/types'
@@ -15,7 +14,7 @@ export const useCollateralBalance = (
   collateralBalance: Maybe<BigNumber>
   fetchCollateralBalance: () => Promise<void>
 } => {
-  const { account, library: provider, relay } = context
+  const { account, library: provider } = context
 
   const [collateralBalance, setCollateralBalance] = useState<Maybe<BigNumber>>(null)
 
@@ -24,10 +23,6 @@ export const useCollateralBalance = (
     if (account) {
       if (collateral.address === pseudoNativeAssetAddress) {
         collateralBalance = await provider.getBalance(account)
-        if (relay) {
-          // subtract the unspendable relay fee
-          collateralBalance = collateralBalance.lt(RELAY_FEE) ? collateralBalance : collateralBalance.sub(RELAY_FEE)
-        }
       } else {
         const collateralService = new ERC20Service(provider, account, collateral.address)
         collateralBalance = await collateralService.getCollateral(account)

--- a/app/src/hooks/useTokens.tsx
+++ b/app/src/hooks/useTokens.tsx
@@ -3,7 +3,6 @@ import { BigNumber } from 'ethers/utils'
 import gql from 'graphql-tag'
 import { useEffect, useState } from 'react'
 
-import { RELAY_FEE } from '../common/constants'
 import { ERC20Service } from '../services'
 import { getLogger } from '../util/logger'
 import { getNativeAsset, getOmenTCRListId, getTokensByNetwork, pseudoNativeAssetAddress } from '../util/networks'
@@ -92,10 +91,6 @@ export const useTokens = (context: ConnectedWeb3Context, addNativeAsset?: boolea
               if (account) {
                 if (token.address === pseudoNativeAssetAddress) {
                   balance = await provider.getBalance(account)
-                  // @ts-expect-error ignore
-                  if (provider.relay) {
-                    balance = balance.lt(RELAY_FEE) ? balance : balance.sub(RELAY_FEE)
-                  }
                 } else {
                   try {
                     const collateralService = new ERC20Service(provider, account, token.address)


### PR DESCRIPTION
PR moves/hides the relay fee as part of transaction amounts, e.g. buy amount, sell amount where possible. So if you deposit 100 dai you can spend 100 dai rather than 99.999 dai. 

Also defaults sells/funding removals as unwraps for the relay (can't pay the relay fee in wxdai).