### PR TITLE
Fixes proxy address vm error for history table

### DIFF
--- a/app/src/components/market/common/history_section/history_select.tsx
+++ b/app/src/components/market/common/history_section/history_select.tsx
@@ -149,7 +149,13 @@ export const History_select: React.FC<Props> = ({
         const response: any[] = await Promise.all(
           fpmmTransactions.map(async item => {
             const safe = new SafeService(item.user.id, context.library)
-            const owners = await safe.getOwners()
+            let owners: string
+            try {
+              const result = await safe.getOwners()
+              owners = result[0].toString()
+            } catch {
+              owners = item.user.id
+            }
             if (item.fpmmType === 'Liquidity') {
               const block: any = await marketMaker.getTransaction(item.transactionHash)
 
@@ -165,11 +171,11 @@ export const History_select: React.FC<Props> = ({
                 ),
                 additionalShares: item.additionalSharesCost,
                 collateralTokenAmount: new BigNumber(item.collateralTokenAmount),
-                user: owners[0],
+                user: owners,
               }
             }
             return {
-              user: owners[0],
+              user: owners,
               id: item.id,
             }
           }),

--- a/app/src/components/market/common/history_section/history_select.tsx
+++ b/app/src/components/market/common/history_section/history_select.tsx
@@ -149,12 +149,12 @@ export const History_select: React.FC<Props> = ({
         const response: any[] = await Promise.all(
           fpmmTransactions.map(async item => {
             const safe = new SafeService(item.user.id, context.library)
-            let owners: string
+            let owner: string
             try {
               const result = await safe.getOwners()
-              owners = result[0].toString()
+              owner = result[0].toString()
             } catch {
-              owners = item.user.id
+              owner = item.user.id
             }
             if (item.fpmmType === 'Liquidity') {
               const block: any = await marketMaker.getTransaction(item.transactionHash)
@@ -171,11 +171,11 @@ export const History_select: React.FC<Props> = ({
                 ),
                 additionalShares: item.additionalSharesCost,
                 collateralTokenAmount: new BigNumber(item.collateralTokenAmount),
-                user: owners,
+                user: owner,
               }
             }
             return {
-              user: owners,
+              user: owner,
               id: item.id,
             }
           }),


### PR DESCRIPTION
- In certain cases like this market http://localhost:3000/#/0x3270f8f76da464e5f38c761b76bea6e7126b798c
- When you go on the history table and click next page it fails on the third
- Because creator is fpmmDeterministicFactory https://blockscout.com/poa/xdai/address/0x9083A2B699c0a4AD06F63580BDE2635d26a3eeF0/transactions
- And that messes up with getOwnerAddress function 
- This fix catches those cases and just displays proxy address 