### PR TITLE
Fix unnecessary market list reload on xdai relay

### DIFF
--- a/app/src/components/market/sections/market_list/market_home_container.tsx
+++ b/app/src/components/market/sections/market_list/market_home_container.tsx
@@ -232,7 +232,9 @@ const MarketHomeContainer: React.FC = () => {
 
   const [markets, setMarkets] = useState<RemoteData<MarketMakerDataItem[]>>(RemoteData.notAsked())
   const [categories, setCategories] = useState<RemoteData<CategoryDataItem[]>>(RemoteData.notAsked())
-  const [cpkAddress, setCpkAddress] = useState<Maybe<string>>(null)
+
+  const defaultCpkAddress = context.relay ? context.account : null
+  const [cpkAddress, setCpkAddress] = useState<Maybe<string>>(defaultCpkAddress)
 
   const [pageSize, setPageSize] = useState(4)
   const [pageIndex, setPageIndex] = useState(0)

--- a/app/src/hooks/connectedBalance.tsx
+++ b/app/src/hooks/connectedBalance.tsx
@@ -5,8 +5,11 @@ import React, { useEffect, useState } from 'react'
 import { STANDARD_DECIMALS } from '../common/constants'
 import { useCollateralBalance, useConnectedWeb3Context, useTokens } from '../hooks'
 import { XdaiService } from '../services'
+import { getLogger } from '../util/logger'
 import { getNativeAsset, networkIds } from '../util/networks'
 import { formatBigNumber, formatNumber } from '../util/tools'
+
+const logger = getLogger('Hooks::ConnectedBalance')
 
 export interface ConnectedBalanceContext {
   claimState: boolean
@@ -80,7 +83,11 @@ export const ConnectedBalance: React.FC<Props> = (props: Props) => {
   }
 
   const fetchBalances = async () => {
-    await Promise.all([fetchUnclaimedAssets(), fetchCollateralBalance(), refetch()])
+    try {
+      await Promise.all([fetchUnclaimedAssets(), fetchCollateralBalance(), refetch()])
+    } catch (e) {
+      logger.log(e)
+    }
   }
 
   useEffect(() => {

--- a/app/src/hooks/connectedBalance.tsx
+++ b/app/src/hooks/connectedBalance.tsx
@@ -68,7 +68,7 @@ export const ConnectedBalance: React.FC<Props> = (props: Props) => {
       const xDaiService = new XdaiService(context.library)
       const transactions = await xDaiService.fetchXdaiTransactionData()
 
-      if (transactions.length) {
+      if (transactions && transactions.length) {
         const aggregator = transactions.reduce((prev: BigNumber, { value }: any) => prev.add(value), Zero)
         setUnclaimedAmount(aggregator)
         setClaimState(true)

--- a/app/src/hooks/connectedBalance.tsx
+++ b/app/src/hooks/connectedBalance.tsx
@@ -86,7 +86,7 @@ export const ConnectedBalance: React.FC<Props> = (props: Props) => {
     try {
       await Promise.all([fetchUnclaimedAssets(), fetchCollateralBalance(), refetch()])
     } catch (e) {
-      logger.log(e)
+      logger.log(e.message)
     }
   }
 


### PR DESCRIPTION
Fixes this sort of annoying double loading of the market list we have on the xdai relay atm:

https://user-images.githubusercontent.com/72715177/113811474-99c7a100-97af-11eb-843b-78c52204ea32.mov

PR also sneaks in two fixes for small errors, one to handle undefined `transactions` response from `fetchXdaiTransactionData` and the other to catch that annoying `refetch of undefined` error we get from hot reloading.