### PR TITLE
Fix/#1804

### DIFF
--- a/app/src/hooks/useCheckContractExists.tsx
+++ b/app/src/hooks/useCheckContractExists.tsx
@@ -11,6 +11,11 @@ export const useCheckContractExists = (marketMakerAddress: string, context: Conn
     let isSubscribed = true
     const provider = context.library
     const fetchIsContract = async () => {
+      if (context.relay) {
+        if (await isContract(context.rawWeb3Context.library, marketMakerAddress)) {
+          return context.toggleRelay()
+        }
+      }
       if (isSubscribed) setContractExists(await isContract(provider, marketMakerAddress))
     }
 

--- a/app/src/hooks/useCheckContractExists.tsx
+++ b/app/src/hooks/useCheckContractExists.tsx
@@ -1,5 +1,7 @@
+import { ethers } from 'ethers'
 import { useEffect, useState } from 'react'
 
+import { getInfuraUrl, networkIds } from '../util/networks'
 import { isContract } from '../util/tools'
 
 import { ConnectedWeb3Context } from './connectedWeb3'
@@ -11,10 +13,13 @@ export const useCheckContractExists = (marketMakerAddress: string, context: Conn
     let isSubscribed = true
     const provider = context.library
     const fetchIsContract = async () => {
-      if (context.relay) {
-        if (await isContract(context.rawWeb3Context.library, marketMakerAddress)) {
-          return context.toggleRelay()
-        }
+      const switchToMainnet = context.relay && (await isContract(context.rawWeb3Context.library, marketMakerAddress))
+      const switchToxDai =
+        context.networkId === networkIds.MAINNET &&
+        !context.relay &&
+        (await isContract(new ethers.providers.JsonRpcProvider(getInfuraUrl(networkIds.XDAI)), marketMakerAddress))
+      if (switchToMainnet || switchToxDai) {
+        return context.toggleRelay()
       }
       if (isSubscribed) setContractExists(await isContract(provider, marketMakerAddress))
     }


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/1804

PR auto switches xdai <-> mainnet depending on what network the market is on.

To test:

mainnet market should auto switch to mainnet: http://localhost:3000/#/0xd450b6c4db569f600cb42acc0a6cd3a140c4894b

xdai market should auto switch to xdai: http://localhost:3000/#/0x287f84de811ff2223c8324ad76fa75d5ea512986