### PR TITLE
Transparent ERC20 wrapping of ERC1155 position tokens

### DIFF
--- a/app/src/components/market/common/market_scale/index.tsx
+++ b/app/src/components/market/common/market_scale/index.tsx
@@ -93,7 +93,7 @@ const HorizontalBar = styled.div`
   top: calc(50% - ${BAR_WIDTH} / 2);
   left: 0;
   right: 0;
-  width: 100%
+  width: 100%;
   height: ${BAR_WIDTH};
   background: ${props => props.theme.scale.bar};
 `
@@ -298,13 +298,13 @@ export const MarketScale: React.FC<Props> = (props: Props) => {
   const shortShares =
     shortBalances &&
     shortBalances.length &&
-    shortBalances.map(shortBalance => shortBalance.shares).reduce((a, b) => a.add(b))
+    shortBalances.map(shortBalance => shortBalance.totalShares).reduce((a, b) => a.add(b))
 
   const longBalances = balances && balances.filter(balance => balance.outcomeName === 'long')
   const longShares =
     longBalances &&
     longBalances.length &&
-    longBalances.map(longBalance => longBalance.shares).reduce((a, b) => a.add(b))
+    longBalances.map(longBalance => longBalance.totalShares).reduce((a, b) => a.add(b))
 
   const shortSharesNumber =
     collateral && Number(formatBigNumber(shortShares || new BigNumber(0), collateral.decimals, STANDARD_DECIMALS))

--- a/app/src/components/market/common/position_selection_box/index.tsx
+++ b/app/src/components/market/common/position_selection_box/index.tsx
@@ -59,7 +59,7 @@ export const PositionSelectionBox = (props: Props) => {
       <PositionSelectionBoxItem>
         <PositionSelectionLeft
           onClick={() => {
-            if (!isDust(balance.shares, decimals)) {
+            if (!isDust(balance.totalShares, decimals)) {
               setBalanceItem(balance)
               setPositionIndex(balances.indexOf(balance))
             }
@@ -67,7 +67,7 @@ export const PositionSelectionBox = (props: Props) => {
         >
           <RadioInput
             checked={balances.indexOf(balance) === positionIndex}
-            disabled={isDust(balance.shares, decimals)}
+            disabled={isDust(balance.totalShares, decimals)}
             name={'position'}
             onClick={() => {
               setBalanceItem(balance)
@@ -78,7 +78,7 @@ export const PositionSelectionBox = (props: Props) => {
           <PositionSelectionTitle>{balance.outcomeName}</PositionSelectionTitle>
         </PositionSelectionLeft>
         <PositionSelectionAmount>
-          {formatNumber(formatBigNumber(balance.shares, decimals))} Shares
+          {formatNumber(formatBigNumber(balance.totalShares, decimals))} Shares
         </PositionSelectionAmount>
       </PositionSelectionBoxItem>
     )

--- a/app/src/components/market/common/position_table/index.tsx
+++ b/app/src/components/market/common/position_table/index.tsx
@@ -16,8 +16,8 @@ import {
 } from '../../common/common_styled'
 
 const TableWrapper = styled.div`
-  margin-left: -24px
-  margin-right: -24px
+  margin-left: -24px;
+  margin-right: -24px;
 `
 
 const ColoredTDStyled = styled(TDStyled as any)<{ positive?: boolean | undefined }>`
@@ -56,8 +56,8 @@ export const PositionTable = (props: Props) => {
 
   const symbol = useSymbol(collateral)
 
-  const shortShares = balances[0].shares
-  const longShares = balances[1].shares
+  const shortShares = balances[0].totalShares
+  const longShares = balances[1].totalShares
   const shortSharesFormatted = formatNumber(formatBigNumber(shortShares || new BigNumber(0), collateral.decimals))
   const longSharesFormatted = formatNumber(formatBigNumber(longShares || new BigNumber(0), collateral.decimals))
 

--- a/app/src/components/market/common/set_allowance/index.tsx
+++ b/app/src/components/market/common/set_allowance/index.tsx
@@ -38,18 +38,21 @@ export type SetAllowanceProps = DOMAttributes<HTMLDivElement> &
   ToggleTokenLockProps & {
     collateral?: Token
     marginBottom?: boolean
+    description?: string
   }
 
 export const SetAllowance: React.FC<SetAllowanceProps> = (props: SetAllowanceProps) => {
-  const { collateral, finished, loading, onUnlock, ...restProps } = props
+  const { collateral, description, finished, loading, onUnlock, ...restProps } = props
 
   return (
     <Wrapper {...restProps}>
       <Title>Set Allowance</Title>
       <DescriptionWrapper>
         <Description>
-          This permission allows the smart contracts to interact with your {collateral && collateral.symbol}. This has
-          to be done for each new token.
+          {description ||
+            `This permission allows the smart contracts to interact with your ${collateral &&
+              collateral.symbol}. This has
+          to be done for each new token.`}
         </Description>
         <ToggleTokenLock finished={finished} loading={loading} onUnlock={onUnlock} />
       </DescriptionWrapper>

--- a/app/src/components/market/common/wrap_erc1155/index.tsx
+++ b/app/src/components/market/common/wrap_erc1155/index.tsx
@@ -1,0 +1,62 @@
+import React, { DOMAttributes, HTMLAttributes } from 'react'
+import styled from 'styled-components'
+
+import { ButtonStateful, ButtonStates } from '../../../button/button_stateful'
+
+const Wrapper = styled.div`
+  border-radius: 4px;
+  border: ${({ theme }) => theme.borders.borderLineDisabled};
+  padding: 21px 25px;
+`
+
+const Title = styled.h2`
+  color: ${props => props.theme.colors.textColorDark};
+  font-size: 16px;
+  letter-spacing: 0.4px;
+  line-height: 1.2;
+  margin: 0 0 20px;
+  font-weight: 400;
+`
+
+const DescriptionWrapper = styled.div`
+  align-items: center;
+  display: flex;
+`
+
+const Description = styled.p`
+  color: ${props => props.theme.colors.textColorLightish};
+  font-size: 14px;
+  letter-spacing: 0.2px;
+  line-height: 1.4;
+  margin: 0 32px 0 0;
+  display: inline-block;
+`
+
+export type WrapERC1155Props = DOMAttributes<HTMLDivElement> &
+  HTMLAttributes<HTMLDivElement> & {
+    marginBottom?: boolean
+    finished?: boolean
+    loading?: boolean
+    onWrap: () => void
+  }
+
+export const WrapERC1155: React.FC<WrapERC1155Props> = (props: WrapERC1155Props) => {
+  const { finished, loading, onWrap, ...restProps } = props
+
+  const state = loading ? ButtonStates.working : finished ? ButtonStates.finished : ButtonStates.idle
+
+  return (
+    <Wrapper {...restProps}>
+      <Title>Upgrade ERC1155</Title>
+      <DescriptionWrapper>
+        <Description>
+          The market has been upgraded to use ERC20 tokens, but your position is still represented using ERC1155 tokens,
+          please upgrade to continue.
+        </Description>
+        <ButtonStateful disabled={loading || finished} onClick={onWrap} state={state}>
+          Upgrade
+        </ButtonStateful>
+      </DescriptionWrapper>
+    </Wrapper>
+  )
+}

--- a/app/src/components/market/sections/market_buy/market_buy.tsx
+++ b/app/src/components/market/sections/market_buy/market_buy.tsx
@@ -85,7 +85,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
   const { library: provider, networkId, relay } = context
   const signer = useMemo(() => provider.getSigner(), [provider])
 
-  const { buildMarketMaker } = useContracts(context)
+  const { buildMarketMaker, conditionalTokens, erc20WrapperFactory } = useContracts(context)
   const { fetchGraphMarketMakerData, marketMakerData, switchMarketTab } = props
   const { address: marketMakerAddress, balances, fee, question } = marketMakerData
   const marketMaker = useMemo(() => buildMarketMaker(marketMakerAddress), [buildMarketMaker, marketMakerAddress])
@@ -237,6 +237,8 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
         amount: inputAmount,
         collateral,
         compoundService,
+        conditionalTokens,
+        erc20WrapperFactory,
         marketMaker,
         outcomeIndex,
         setTxHash,

--- a/app/src/components/market/sections/market_buy/scalar_market_buy.tsx
+++ b/app/src/components/market/sections/market_buy/scalar_market_buy.tsx
@@ -81,7 +81,7 @@ export const ScalarMarketBuy = (props: Props) => {
     scalarHigh,
     scalarLow,
   } = marketMakerData
-  const { buildMarketMaker } = useContracts(context)
+  const { buildMarketMaker, conditionalTokens, erc20WrapperFactory } = useContracts(context)
   const marketMaker = useMemo(() => buildMarketMaker(marketMakerAddress), [buildMarketMaker, marketMakerAddress])
 
   const Tabs = {
@@ -255,6 +255,8 @@ export const ScalarMarketBuy = (props: Props) => {
       await cpk.buyOutcomes({
         amount,
         collateral,
+        conditionalTokens,
+        erc20WrapperFactory,
         outcomeIndex,
         marketMaker,
         setTxHash,

--- a/app/src/components/market/sections/market_create/market_wizard_creator.tsx
+++ b/app/src/components/market/sections/market_create/market_wizard_creator.tsx
@@ -44,6 +44,7 @@ export const MarketWizardCreator = (props: Props) => {
   const marketDataDefault: MarketData = {
     arbitrator: defaultArbitrator,
     arbitratorsCustom: [],
+    baseERC20TokenSymbol: '',
     categoriesCustom: [],
     category: '',
     collateral: defaultCollateral,

--- a/app/src/components/market/sections/market_create/market_wizard_creator_container.tsx
+++ b/app/src/components/market/sections/market_create/market_wizard_creator_container.tsx
@@ -23,7 +23,7 @@ const MarketWizardCreatorContainer: FC = () => {
   const history = useHistory()
 
   const [isModalOpen, setModalState] = useState(false)
-  const { conditionalTokens, marketMakerFactory, realitio } = useContracts(context)
+  const { conditionalTokens, erc20WrapperFactory, marketMakerFactory, realitio } = useContracts(context)
 
   const [marketCreationStatus, setMarketCreationStatus] = useState<MarketCreationStatus>(MarketCreationStatus.ready())
   const [marketMakerAddress, setMarketMakerAddress] = useState<string | null>(null)
@@ -79,6 +79,7 @@ const MarketWizardCreatorContainer: FC = () => {
           const { marketMakerAddress } = await cpk.createScalarMarket({
             marketData,
             conditionalTokens,
+            erc20WrapperFactory,
             realitio,
             marketMakerFactory,
             setTxHash,
@@ -107,6 +108,7 @@ const MarketWizardCreatorContainer: FC = () => {
             compoundTokenDetails,
             marketData,
             conditionalTokens,
+            erc20WrapperFactory,
             realitio,
             marketMakerFactory,
             setTxHash,

--- a/app/src/components/market/sections/market_create/steps/items/ask_question_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/ask_question_step.tsx
@@ -9,7 +9,7 @@ import { useConnectedWeb3Context } from '../../../../../../hooks/connectedWeb3'
 import { Arbitrator, FormState, Question } from '../../../../../../util/types'
 import { Button, ButtonContainer } from '../../../../../button'
 import { ButtonType } from '../../../../../button/button_styling_types'
-import { DateField, FormRow, FormStateButton } from '../../../../../common'
+import { DateField, FormRow, FormStateButton, Textfield } from '../../../../../common'
 import { BigNumberInputReturn } from '../../../../../common/form/big_number_input'
 import { CommonDisabledCSS } from '../../../../../common/form/common_styled'
 import { QuestionInput } from '../../../../../common/form/question_input'
@@ -122,6 +122,7 @@ interface Props {
     upperBound: Maybe<BigNumber>
     startingPoint: Maybe<BigNumber>
     unit: string
+    baseERC20TokenSymbol: string
   }
   addArbitratorCustom: (arbitrator: Arbitrator) => void
   addCategoryCustom: (category: string) => void
@@ -158,6 +159,7 @@ const AskQuestionStep = (props: Props) => {
   const {
     arbitrator,
     arbitratorsCustom,
+    baseERC20TokenSymbol,
     categoriesCustom,
     category,
     loadedQuestionId,
@@ -293,6 +295,7 @@ const AskQuestionStep = (props: Props) => {
         <CreateScalarMarket
           arbitrator={arbitrator}
           arbitratorsCustom={arbitratorsCustom}
+          baseERC20TokenSymbol={baseERC20TokenSymbol}
           categoriesCustom={categoriesCustom}
           category={category}
           categoryButtonFocus={categoryButtonFocus}
@@ -333,6 +336,17 @@ const AskQuestionStep = (props: Props) => {
             onChange={handleOutcomesChange}
             outcomes={outcomes}
             totalProbabilities={totalProbabilities}
+          />
+          <FormRow
+            formField={
+              <Textfield
+                name="baseERC20TokenSymbol"
+                onChange={handleChange}
+                placeholder="The base symbol of the ERC20 token"
+                value={baseERC20TokenSymbol}
+              />
+            }
+            title="Base ERC20 token symbol"
           />
           <GridTwoColumns>
             <Column>

--- a/app/src/components/market/sections/market_create/steps/items/create_scalar_market.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/create_scalar_market.tsx
@@ -97,6 +97,7 @@ interface Props {
   toggleCategoryButtonFocus: () => void
   arbitrator: Arbitrator
   handleArbitratorChange: (arbitrator: Arbitrator) => any
+  baseERC20TokenSymbol: string
   arbitratorsCustom: Arbitrator[]
 }
 
@@ -104,6 +105,7 @@ export const CreateScalarMarket = (props: Props) => {
   const {
     arbitrator,
     arbitratorsCustom,
+    baseERC20TokenSymbol,
     categoriesCustom,
     category,
     categoryButtonFocus,
@@ -187,6 +189,17 @@ export const CreateScalarMarket = (props: Props) => {
             title={'Unit of measurement'}
           />
         </Row>
+        <FormRow
+          formField={
+            <Textfield
+              name="baseERC20TokenSymbol"
+              onChange={handleChange}
+              placeholder="ETHLONG"
+              value={baseERC20TokenSymbol}
+            />
+          }
+          title="Base ERC20 token name"
+        />
         <Row>
           <FormRow
             formField={

--- a/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
+++ b/app/src/components/market/sections/market_create/steps/items/funding_and_fee_step.tsx
@@ -19,6 +19,7 @@ import {
   useCpkProxy,
 } from '../../../../../../hooks'
 import { useGraphMarketsFromQuestion } from '../../../../../../hooks/useGraphMarketsFromQuestion'
+import { ERC20WrapperService } from '../../../../../../services/erc20_wrapper'
 import { BalanceState, fetchAccountBalance } from '../../../../../../store/reducer'
 import { MarketCreationStatus } from '../../../../../../util/market_creation_status_data'
 import { getNativeAsset, networkIds, pseudoNativeAssetAddress } from '../../../../../../util/networks'
@@ -167,6 +168,7 @@ interface Props {
   back: (state: string) => void
   submit: (isScalar: boolean) => void
   values: {
+    baseERC20TokenSymbol: string
     collateral: Token
     question: string
     category: string
@@ -218,6 +220,7 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
 
   const {
     arbitrator,
+    baseERC20TokenSymbol,
     category,
     collateral,
     funding,
@@ -438,8 +441,9 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
             <OutcomesTable>
               <OutcomesTHead>
                 <OutcomesTR>
-                  <OutcomesTH style={{ width: '60%' }}>Outcome</OutcomesTH>
+                  <OutcomesTH style={{ width: '40%' }}>Outcome</OutcomesTH>
                   <OutcomesTH>Probability</OutcomesTH>
+                  <OutcomesTH>ERC20 token</OutcomesTH>
                 </OutcomesTR>
               </OutcomesTHead>
               <OutcomesTBody>
@@ -453,6 +457,13 @@ const FundingAndFeeStep: React.FC<Props> = (props: Props) => {
                         </OutcomeItemTextWrapper>
                       </OutcomesTD>
                       <OutcomesTD>{outcome.probability.toFixed(2)}%</OutcomesTD>
+                      <OutcomesTD>
+                        {ERC20WrapperService.predictSymbol(
+                          baseERC20TokenSymbol,
+                          outcome.name,
+                          resolution || new Date(),
+                        )}
+                      </OutcomesTD>
                     </OutcomesTR>
                   )
                 })}

--- a/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
@@ -193,8 +193,8 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
     totalPoolShares,
   )
   const sharesAfterAddingFunding = sendAmountsAfterAddingFunding
-    ? balances.map((balance, i) => balance.shares.add(sendAmountsAfterAddingFunding[i]))
-    : balances.map(balance => balance.shares)
+    ? balances.map((balance, i) => balance.totalShares.add(sendAmountsAfterAddingFunding[i]))
+    : balances.map(balance => balance.totalShares)
 
   const sendAmountsAfterRemovingFunding = calcRemoveFundingSendAmounts(
     amountToRemove || Zero,
@@ -206,7 +206,7 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
   )
 
   const sharesAfterRemovingFunding = balances.map((balance, i) => {
-    return balance.shares.add(sendAmountsAfterRemovingFunding[i]).sub(depositedTokens)
+    return balance.totalShares.add(sendAmountsAfterRemovingFunding[i]).sub(depositedTokens)
   })
 
   const showSharesChange = activeTab === Tabs.deposit ? amountToFund?.gt(0) : amountToRemove?.gt(0)

--- a/app/src/components/market/sections/market_profile/market_status/closed.tsx
+++ b/app/src/components/market/sections/market_profile/market_status/closed.tsx
@@ -364,18 +364,18 @@ const Wrapper = (props: Props) => {
   const earnedCollateral = isScalar
     ? scalarComputeEarnedCollateral(
         finalAnswerPercentage,
-        balances.map(balance => balance.shares),
+        balances.map(balance => balance.totalShares),
       )
     : computeEarnedCollateral(
         payouts,
-        balances.map(balance => balance.shares),
+        balances.map(balance => balance.totalShares),
       )
 
   const hasWinningOutcomes = earnedCollateral && !isDust(earnedCollateral, collateralToken.decimals)
 
   const { userWinningOutcomes, userWinningShares, winningOutcomes } = calcUserWinningsData(
     isScalar,
-    balances.map(balance => balance.shares),
+    balances.map(balance => balance.totalShares),
     payouts,
     finalAnswerPercentage,
   )

--- a/app/src/components/market/sections/market_profile/market_status/open.tsx
+++ b/app/src/components/market/sections/market_profile/market_status/open.tsx
@@ -161,8 +161,8 @@ const Wrapper = (props: Props) => {
     displayBalances = getSharesInBaseToken(balances, compoundService, displayCollateral)
   }
   const userHasShares = balances.some((balanceItem: BalanceItem) => {
-    const { shares } = balanceItem
-    return shares && !isDust(shares, collateral.decimals)
+    const { totalShares } = balanceItem
+    return totalShares && !isDust(totalShares, collateral.decimals)
   })
 
   const probabilities = balances.map(balance => balance.probability)

--- a/app/src/components/market/sections/market_sell/market_sell.tsx
+++ b/app/src/components/market/sections/market_sell/market_sell.tsx
@@ -77,7 +77,7 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
   const { networkId, relay } = context
   const cpk = useConnectedCPKContext()
   const { fetchBalances } = useConnectedBalanceContext()
-  const { buildMarketMaker, conditionalTokens } = useContracts(context)
+  const { buildMarketMaker, conditionalTokens, erc20WrapperFactory } = useContracts(context)
   const { fetchGraphMarketMakerData, marketMakerData, switchMarketTab } = props
   const { address: marketMakerAddress, balances, collateral, conditionId, fee, outcomeTokenAmounts } = marketMakerData
   const erc20PositionWrappers = useERC1155TokenWrappers(conditionId, outcomeTokenAmounts.length, collateral.address)
@@ -121,10 +121,6 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
     if (!amountShares || amountShares.isZero()) return Ternary.True
     return RemoteData.mapToTernary(allowance, allowance => allowance.gte(amountShares))
   }, [allowance, amountShares])
-  const selectedOutcomeERC20Wrapper = useMemo(() => erc20PositionWrappers[outcomeIndex], [
-    erc20PositionWrappers,
-    outcomeIndex,
-  ])
 
   const { compoundService: CompoundService } = useCompoundService(collateral, context)
   const compoundService = CompoundService || null
@@ -263,7 +259,7 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
       await cpk.sellOutcomes({
         amount: tradedCollateral,
         compoundService,
-        erc20Wrapper: selectedOutcomeERC20Wrapper,
+        erc20WrapperFactory,
         outcomeIndex,
         marketMaker,
         conditionalTokens,

--- a/app/src/components/market/sections/market_sell/market_sell.tsx
+++ b/app/src/components/market/sections/market_sell/market_sell.tsx
@@ -205,7 +205,7 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
     calcSellAmount,
   )
 
-  const unlockCollateral = useCallback(async () => {
+  const unlockWrappedToken = useCallback(async () => {
     if (!cpk) return
     await cpkAllowances[outcomeIndex].unlock()
     setAllowanceFinished(true)
@@ -489,7 +489,8 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
           description="This permission allows Omen smart contracts to interact with your Outcome Shares. This has to be done for each new Outcome Share"
           finished={allowanceFinished && RemoteData.is.success(allowance)}
           loading={RemoteData.is.asking(allowance)}
-          onUnlock={unlockCollateral}
+          onUnlock={unlockWrappedToken}
+          style={{ marginBottom: 20 }}
         />
       )}
       <StyledButtonContainer borderTop={true} marginTop={isNegativeAmountShares}>

--- a/app/src/components/market/sections/market_sell/scalar_market_sell.tsx
+++ b/app/src/components/market/sections/market_sell/scalar_market_sell.tsx
@@ -13,6 +13,7 @@ import {
   useSymbol,
 } from '../../../../hooks'
 import { MarketMakerService } from '../../../../services'
+import { ERC20WrapperService } from '../../../../services/erc20_wrapper'
 import { getLogger } from '../../../../util/logger'
 import {
   calcPrediction,
@@ -190,6 +191,8 @@ export const ScalarMarketSell = (props: Props) => {
       await cpk.sellOutcomes({
         amount: tradedCollateral,
         conditionalTokens,
+        // TODO: actually implement allowance check for scalar markets
+        erc20Wrapper: new ERC20WrapperService('0x0', context.library),
         marketMaker,
         outcomeIndex,
         setTxHash,

--- a/app/src/components/market/sections/market_sell/scalar_market_sell.tsx
+++ b/app/src/components/market/sections/market_sell/scalar_market_sell.tsx
@@ -13,7 +13,6 @@ import {
   useSymbol,
 } from '../../../../hooks'
 import { MarketMakerService } from '../../../../services'
-import { ERC20WrapperService } from '../../../../services/erc20_wrapper'
 import { getLogger } from '../../../../util/logger'
 import {
   calcPrediction,
@@ -75,7 +74,7 @@ export const ScalarMarketSell = (props: Props) => {
     scalarHigh,
     scalarLow,
   } = marketMakerData
-  const { buildMarketMaker, conditionalTokens } = useContracts(context)
+  const { buildMarketMaker, conditionalTokens, erc20WrapperFactory } = useContracts(context)
   const marketMaker = useMemo(() => buildMarketMaker(marketMakerAddress), [buildMarketMaker, marketMakerAddress])
 
   const [positionIndex, setPositionIndex] = useState(balances[0].shares.gte(balances[1].shares) ? 0 : 1)
@@ -192,7 +191,7 @@ export const ScalarMarketSell = (props: Props) => {
         amount: tradedCollateral,
         conditionalTokens,
         // TODO: actually implement allowance check for scalar markets
-        erc20Wrapper: new ERC20WrapperService('0x0', context.library),
+        erc20WrapperFactory,
         marketMaker,
         outcomeIndex,
         setTxHash,

--- a/app/src/hooks/useBlockchainMarketMakerData.tsx
+++ b/app/src/hooks/useBlockchainMarketMakerData.tsx
@@ -126,8 +126,8 @@ export const useBlockchainMarketMakerData = (graphMarketMakerData: Maybe<GraphMa
     } = await promiseProps({
       marketMakerShares: marketMaker.getBalanceInformation(graphMarketMakerData.address, outcomesLength),
       userShares:
-        cpk && cpk.address
-          ? marketMaker.getBalanceInformation(cpk.address, outcomesLength)
+        cpk && cpk.address && context.account
+          ? marketMaker.getBalanceInformation(context.account, outcomesLength)
           : outcomes.length
           ? outcomes.map(() => new BigNumber(0))
           : [],

--- a/app/src/hooks/useBlockchainMarketMakerData.tsx
+++ b/app/src/hooks/useBlockchainMarketMakerData.tsx
@@ -124,10 +124,10 @@ export const useBlockchainMarketMakerData = (graphMarketMakerData: Maybe<GraphMa
       userPoolShares,
       userShares,
     } = await promiseProps({
-      marketMakerShares: marketMaker.getBalanceInformation(graphMarketMakerData.address, outcomesLength),
+      marketMakerShares: marketMaker.getERC1155BalanceInformation(graphMarketMakerData.address, outcomesLength),
       userShares:
         cpk && cpk.address && context.account
-          ? marketMaker.getBalanceInformation(context.account, outcomesLength)
+          ? marketMaker.getERC20BalanceInformation(context.account, outcomesLength)
           : outcomes.length
           ? outcomes.map(() => new BigNumber(0))
           : [],
@@ -167,6 +167,7 @@ export const useBlockchainMarketMakerData = (graphMarketMakerData: Maybe<GraphMa
       arbitrator,
       balances,
       collateral,
+      conditionId: graphMarketMakerData.conditionId,
       creator: graphMarketMakerData.creator,
       fee: graphMarketMakerData.fee,
       collateralVolume: graphMarketMakerData.collateralVolume,
@@ -199,7 +200,7 @@ export const useBlockchainMarketMakerData = (graphMarketMakerData: Maybe<GraphMa
 
     setMarketMakerData(newMarketMakerData)
     setStatus(Status.Ready)
-  }, [graphMarketMakerData, provider, contracts, networkId, cpk])
+  }, [context.account, graphMarketMakerData, provider, contracts, networkId, cpk])
 
   const fetchData = useCallback(async () => {
     try {

--- a/app/src/hooks/useContracts.tsx
+++ b/app/src/hooks/useContracts.tsx
@@ -65,8 +65,9 @@ export const useContracts = (context: ConnectedWeb3Context) => {
   )
 
   const buildMarketMaker = useMemo(
-    () => (address: string) => new MarketMakerService(address, conditionalTokens, realitio, provider, account),
-    [conditionalTokens, realitio, provider, account],
+    () => (address: string) =>
+      new MarketMakerService(address, conditionalTokens, erc20WrapperFactory, realitio, provider, account),
+    [conditionalTokens, erc20WrapperFactory, realitio, provider, account],
   )
 
   const dxTCRAddress = getContractAddress(networkId, 'dxTCR')

--- a/app/src/hooks/useContracts.tsx
+++ b/app/src/hooks/useContracts.tsx
@@ -10,6 +10,7 @@ import {
   OracleService,
   RealitioService,
 } from '../services'
+import { ERC20WrapperFactoryService } from '../services/erc20_wrapper_factory'
 import { getContractAddress } from '../util/networks'
 
 import { ConnectedWeb3Context } from './connectedWeb3'
@@ -28,6 +29,12 @@ export const useContracts = (context: ConnectedWeb3Context) => {
     () => new MarketMakerFactoryService(marketMakerFactoryAddress, provider, account),
     [marketMakerFactoryAddress, provider, account],
   )
+
+  const erc20WrapperFactoryAddress = getContractAddress(networkId, 'erc20WrapperFactory')
+  const erc20WrapperFactory = useMemo(() => new ERC20WrapperFactoryService(erc20WrapperFactoryAddress, provider), [
+    erc20WrapperFactoryAddress,
+    provider,
+  ])
 
   const realitioAddress = getContractAddress(networkId, 'realitio')
   const realitioScalarAdapterAddress = getContractAddress(networkId, 'realitioScalarAdapter')
@@ -69,13 +76,14 @@ export const useContracts = (context: ConnectedWeb3Context) => {
     () => ({
       conditionalTokens,
       marketMakerFactory,
+      erc20WrapperFactory,
       realitio,
       oracle,
       buildMarketMaker,
       kleros,
       dxTCR,
     }),
-    [conditionalTokens, marketMakerFactory, realitio, oracle, kleros, buildMarketMaker, dxTCR],
+    [conditionalTokens, erc20WrapperFactory, marketMakerFactory, realitio, oracle, kleros, buildMarketMaker, dxTCR],
   )
 }
 

--- a/app/src/hooks/useCpkAllowances.tsx
+++ b/app/src/hooks/useCpkAllowances.tsx
@@ -1,0 +1,63 @@
+import { MaxUint256 } from 'ethers/constants'
+import { BigNumber } from 'ethers/utils'
+import { useCallback, useEffect, useState } from 'react'
+
+import { ERC20Service } from '../services'
+import { pseudoNativeAssetAddress } from '../util/networks'
+import { RemoteData } from '../util/remote_data'
+
+import { useConnectedCPKContext } from './connectedCpk'
+import { useConnectedWeb3Context } from './connectedWeb3'
+
+interface CpkAllowance {
+  allowance: RemoteData<BigNumber>
+  unlock: () => Promise<void>
+}
+
+export const useCpkAllowances = (account: string | null, tokenAddresses: string[]): CpkAllowance[] => {
+  const { library: provider } = useConnectedWeb3Context()
+  const cpk = useConnectedCPKContext()
+  const [allowances, setAllowances] = useState<CpkAllowance[]>([])
+
+  const updateAllowances = useCallback(async () => {
+    if (
+      cpk &&
+      provider &&
+      account &&
+      tokenAddresses.length > 0 &&
+      tokenAddresses.every(tokenAddress => tokenAddress !== pseudoNativeAssetAddress)
+    ) {
+      const allowances: CpkAllowance[] = []
+      for (let i = 0; i < tokenAddresses.length; i++) {
+        const collateralService = new ERC20Service(provider, account, tokenAddresses[i])
+        let allowance
+        try {
+          allowance = RemoteData.success(await collateralService.allowance(account, cpk.address))
+        } catch (error) {
+          allowance = RemoteData.failure(error)
+        }
+        allowances.push({
+          allowance,
+          unlock: async () => {
+            allowances[i].allowance = RemoteData.load(allowances[i].allowance)
+            setAllowances([...allowances])
+            try {
+              await collateralService.approveUnlimited(cpk.address)
+              allowances[i].allowance = RemoteData.success(MaxUint256)
+            } catch (error) {
+              allowances[i].allowance = RemoteData.failure(error)
+            }
+            setAllowances([...allowances])
+          },
+        })
+      }
+      setAllowances(allowances)
+    }
+  }, [tokenAddresses, cpk, provider, account])
+
+  useEffect(() => {
+    updateAllowances()
+  }, [updateAllowances])
+
+  return allowances
+}

--- a/app/src/hooks/useCpkAllowances.tsx
+++ b/app/src/hooks/useCpkAllowances.tsx
@@ -14,7 +14,7 @@ interface CpkAllowance {
   unlock: () => Promise<void>
 }
 
-export const useCpkAllowances = (account: string | null, tokenAddresses: string[]): CpkAllowance[] => {
+export const useCpkAllowances = (account: string | null, tokenAddresses: string[] | null): CpkAllowance[] => {
   const { library: provider } = useConnectedWeb3Context()
   const cpk = useConnectedCPKContext()
   const [allowances, setAllowances] = useState<CpkAllowance[]>([])
@@ -24,6 +24,7 @@ export const useCpkAllowances = (account: string | null, tokenAddresses: string[
       cpk &&
       provider &&
       account &&
+      tokenAddresses &&
       tokenAddresses.length > 0 &&
       tokenAddresses.every(tokenAddress => tokenAddress !== pseudoNativeAssetAddress)
     ) {

--- a/app/src/hooks/useERC1155TokenWrappers.tsx
+++ b/app/src/hooks/useERC1155TokenWrappers.tsx
@@ -1,27 +1,46 @@
 import { useEffect, useState } from 'react'
 
-import { ERC20Service } from '../services'
+import { MarketMakerService } from '../services'
 import { ERC20WrapperService } from '../services/erc20_wrapper'
 
 import { useConnectedWeb3Context } from './connectedWeb3'
 import { useContracts } from './useContracts'
 
-export const useERC1155TokenWrappers = (conditionId: string, outcomesAmount: number, collateralAddress: string) => {
+/**
+ * Given a certain condition id, the amount of outcomes and a specific collateral token,
+ * returns the addresses of the ERC20 token wrappers for each position, if any.
+ * If the market does not support ERC20 wrapping (due to being too old for example),
+ * `null` is returned.
+ *
+ * @param conditionId The condition id.
+ * @param outcomesAmount The amount of outcomes.
+ * @param collateralAddress The collateral address.
+ */
+export const useERC1155TokenWrappers = (
+  marketMaker: MarketMakerService,
+  conditionId: string,
+  outcomesAmount: number,
+  collateralAddress: string,
+): ERC20WrapperService[] | null => {
   const web3Context = useConnectedWeb3Context()
   const { conditionalTokens, erc20WrapperFactory } = useContracts(web3Context)
-  const [wrappers, setWrappers] = useState<ERC20Service[]>([])
+  const [wrappers, setWrappers] = useState<ERC20WrapperService[] | null>(null)
 
   useEffect(() => {
     const fetchData = async () => {
+      if (!(await erc20WrapperFactory.marketWrapped(conditionalTokens, marketMaker, outcomesAmount))) {
+        setWrappers(null)
+        return
+      }
       const wrappers = []
       for (let i = 0; i < outcomesAmount; i++) {
         const collectionId = await conditionalTokens.getCollectionIdForOutcome(conditionId, 1 << i)
         const positionId = await conditionalTokens.getPositionId(collateralAddress, collectionId)
         wrappers.push(
-          new ERC20Service(
-            web3Context.library,
-            web3Context.account,
+          new ERC20WrapperService(
             ERC20WrapperService.predictAddress(erc20WrapperFactory.address, positionId),
+            positionId,
+            web3Context.library,
           ),
         )
       }
@@ -36,6 +55,7 @@ export const useERC1155TokenWrappers = (conditionId: string, outcomesAmount: num
     outcomesAmount,
     web3Context.account,
     web3Context.library,
+    marketMaker,
   ])
 
   return wrappers

--- a/app/src/hooks/useERC1155TokenWrappers.tsx
+++ b/app/src/hooks/useERC1155TokenWrappers.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+
+import { ERC20Service } from '../services'
+
+import { useConnectedWeb3Context } from './connectedWeb3'
+import { useContracts } from './useContracts'
+
+export const useERC1155TokenWrappers = (conditionId: string, outcomesAmount: number, collateralAddress: string) => {
+  const web3Context = useConnectedWeb3Context()
+  const { conditionalTokens, erc20WrapperFactory } = useContracts(web3Context)
+  const [wrappers, setWrappers] = useState<ERC20Service[]>([])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const wrappers = []
+      for (let i = 0; i < outcomesAmount; i++) {
+        const collectionId = await conditionalTokens.getCollectionIdForOutcome(conditionId, 1 << i)
+        const positionId = await conditionalTokens.getPositionId(collateralAddress, collectionId)
+        const erc20WrapperAddress = await erc20WrapperFactory.wrapperForPosition(positionId)
+        wrappers.push(new ERC20Service(web3Context.library, web3Context.account, erc20WrapperAddress))
+      }
+      setWrappers(wrappers)
+    }
+    fetchData()
+  }, [
+    collateralAddress,
+    conditionId,
+    conditionalTokens,
+    erc20WrapperFactory,
+    outcomesAmount,
+    web3Context.account,
+    web3Context.library,
+  ])
+
+  return wrappers
+}

--- a/app/src/hooks/useERC1155TokenWrappers.tsx
+++ b/app/src/hooks/useERC1155TokenWrappers.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { ERC20Service } from '../services'
+import { ERC20WrapperService } from '../services/erc20_wrapper'
 
 import { useConnectedWeb3Context } from './connectedWeb3'
 import { useContracts } from './useContracts'
@@ -16,8 +17,13 @@ export const useERC1155TokenWrappers = (conditionId: string, outcomesAmount: num
       for (let i = 0; i < outcomesAmount; i++) {
         const collectionId = await conditionalTokens.getCollectionIdForOutcome(conditionId, 1 << i)
         const positionId = await conditionalTokens.getPositionId(collateralAddress, collectionId)
-        const erc20WrapperAddress = await erc20WrapperFactory.wrapperForPosition(positionId)
-        wrappers.push(new ERC20Service(web3Context.library, web3Context.account, erc20WrapperAddress))
+        wrappers.push(
+          new ERC20Service(
+            web3Context.library,
+            web3Context.account,
+            ERC20WrapperService.predictAddress(erc20WrapperFactory.address, positionId),
+          ),
+        )
       }
       setWrappers(wrappers)
     }

--- a/app/src/services/cpk.ts
+++ b/app/src/services/cpk.ts
@@ -700,7 +700,6 @@ class CPKService {
 
       const transactions: Transaction[] = []
       const txOptions: TxOptions = {}
-      txOptions.gas = defaultGas
 
       let collateral
 

--- a/app/src/services/cpk.ts
+++ b/app/src/services/cpk.ts
@@ -435,7 +435,6 @@ class CPKService {
 
       const transactions: Transaction[] = []
       const txOptions: TxOptions = {}
-      txOptions.gas = defaultGas
 
       let collateral: any
       const fundingAmount = this.cpk.relay ? marketData.funding.sub(RELAY_FEE) : marketData.funding
@@ -594,12 +593,12 @@ class CPKService {
       // Step 6: create ERC20 wrappers for each position
       await Promise.all(
         outcomes.map(async (_, index) => {
-          // const collectionId = await conditionalTokens.getCollectionIdForOutcome(conditionId, index)
-          // const positionId = await conditionalTokens.getPositionId(collateral.address, collectionId)
+          const collectionId = await conditionalTokens.getCollectionIdForOutcome(conditionId, index)
+          const positionId = await conditionalTokens.getPositionId(collateral.address, collectionId)
           transactions.push({
             to: erc20WrapperFactory.contract.address,
             // TODO: choose proper name and symbol
-            data: ERC20WrapperFactoryService.encodeCreateWrapperCall('Test', 'TEST', 1),
+            data: ERC20WrapperFactoryService.encodeCreateWrapperCall('Test', 'TEST', positionId),
           })
         }),
       )

--- a/app/src/services/cpk.ts
+++ b/app/src/services/cpk.ts
@@ -594,12 +594,12 @@ class CPKService {
       // Step 6: create ERC20 wrappers for each position
       await Promise.all(
         outcomes.map(async (_, index) => {
-          const collectionId = await conditionalTokens.getCollectionIdForOutcome(conditionId, index)
-          const positionId = await conditionalTokens.getPositionId(collateral.address, collectionId)
+          // const collectionId = await conditionalTokens.getCollectionIdForOutcome(conditionId, index)
+          // const positionId = await conditionalTokens.getPositionId(collateral.address, collectionId)
           transactions.push({
             to: erc20WrapperFactory.contract.address,
             // TODO: choose proper name and symbol
-            data: ERC20WrapperFactoryService.encodeCreateWrapperCall('Test', 'TEST', positionId),
+            data: ERC20WrapperFactoryService.encodeCreateWrapperCall('Test', 'TEST', 1),
           })
         }),
       )

--- a/app/src/services/cpk.ts
+++ b/app/src/services/cpk.ts
@@ -438,6 +438,7 @@ class CPKService {
     try {
       const {
         arbitrator,
+        baseERC20TokenSymbol,
         category,
         loadedQuestionId,
         outcomes,
@@ -449,6 +450,10 @@ class CPKService {
 
       if (!resolution) {
         throw new Error('Resolution time was not specified')
+      }
+
+      if (!baseERC20TokenSymbol) {
+        throw new Error('Base ERC20 token symbol was not specified')
       }
 
       const signer = this.provider.getSigner()
@@ -624,10 +629,14 @@ class CPKService {
         outcomes.map(async (_, index) => {
           const collectionId = await conditionalTokens.getCollectionIdForOutcome(conditionId, 1 << index)
           const positionId = await conditionalTokens.getPositionId(collateral.address, collectionId)
+          const outcome = outcomes[index]
           transactions.push({
             to: erc20WrapperFactory.contract.address,
-            // TODO: choose proper name and symbol
-            data: ERC20WrapperFactoryService.encodeCreateWrapperCall('Test', 'TEST', positionId),
+            data: ERC20WrapperFactoryService.encodeCreateWrapperCall(
+              ERC20WrapperService.predictName(question, outcome.name, resolution),
+              ERC20WrapperService.predictSymbol(baseERC20TokenSymbol, outcome.name, resolution),
+              positionId,
+            ),
           })
         }),
       )
@@ -655,6 +664,7 @@ class CPKService {
     try {
       const {
         arbitrator,
+        baseERC20TokenSymbol,
         category,
         loadedQuestionId,
         lowerBound,
@@ -680,6 +690,10 @@ class CPKService {
 
       if (!startingPoint) {
         throw new Error('Starting expected value not specified')
+      }
+
+      if (!baseERC20TokenSymbol) {
+        throw new Error('Base ERC20 token symbol expected value not specified')
       }
 
       if (lowerBound.gt(startingPoint) || startingPoint.gt(upperBound)) {
@@ -832,10 +846,14 @@ class CPKService {
       for (let i = 0; i < 2; i++) {
         const collectionId = await conditionalTokens.getCollectionIdForOutcome(conditionId, 1 << i)
         const positionId = await conditionalTokens.getPositionId(collateral.address, collectionId)
+        const outcomeName = i === 0 ? 'Short' : 'Long'
         transactions.push({
           to: erc20WrapperFactory.contract.address,
-          // TODO: choose proper name and symbol
-          data: ERC20WrapperFactoryService.encodeCreateWrapperCall('Test', 'TEST', positionId),
+          data: ERC20WrapperFactoryService.encodeCreateWrapperCall(
+            ERC20WrapperService.predictName(question, outcomeName, resolution),
+            ERC20WrapperService.predictSymbol(baseERC20TokenSymbol, outcomeName, resolution),
+            positionId,
+          ),
         })
       }
 

--- a/app/src/services/erc20.ts
+++ b/app/src/services/erc20.ts
@@ -128,6 +128,14 @@ class ERC20Service {
     }
   }
 
+  balanceOf = (account: string): BigNumber => {
+    return this.contract.balanceOf(account)
+  }
+
+  balanceOfByBlock = async (account: string, block: number): Promise<BigNumber> => {
+    return this.contract.balanceOf(account, { blockTag: block })
+  }
+
   static encodeTransferFrom = (from: string, to: string, amount: BigNumber): string => {
     const transferFromInterface = new utils.Interface(erc20Abi)
 

--- a/app/src/services/erc20_wrapper.ts
+++ b/app/src/services/erc20_wrapper.ts
@@ -1,5 +1,6 @@
 import { Contract, utils } from 'ethers'
 import { BigNumber, getCreate2Address, solidityKeccak256, solidityPack } from 'ethers/utils'
+import moment from 'moment'
 
 const INIT_CODE_HASH = '0x5058e67e4d72ed90876a53ce32f1bdd8b0f8a4f56cce190f0f25fa4dbe3e1160'
 const WRAPPER_INTERFACE = new utils.Interface([`function withdraw(uint256 _amount) external`])
@@ -20,6 +21,14 @@ class ERC20WrapperService {
 
   static encodeWithdraw = (amount: BigNumber): string => {
     return WRAPPER_INTERFACE.functions.withdraw.encode([amount])
+  }
+
+  static predictName = (question: string, outcomeName: string, resolution: Date): string => {
+    return `${question} - ${outcomeName} - ${moment(resolution).format('DD/MM/YYYY HH:mm')}`
+  }
+
+  static predictSymbol = (baseERC20TokenSymbol: string, outcomeName: string, resolution: Date): string => {
+    return `o${baseERC20TokenSymbol}.${outcomeName.toUpperCase()}.${moment(resolution).format('DD/MM/YYYY/HH:mm')}`
   }
 }
 

--- a/app/src/services/erc20_wrapper.ts
+++ b/app/src/services/erc20_wrapper.ts
@@ -2,14 +2,18 @@ import { Contract, utils } from 'ethers'
 import { BigNumber, getCreate2Address, solidityKeccak256, solidityPack } from 'ethers/utils'
 import moment from 'moment'
 
-const INIT_CODE_HASH = '0x5058e67e4d72ed90876a53ce32f1bdd8b0f8a4f56cce190f0f25fa4dbe3e1160'
+const INIT_CODE_HASH = '0x9d473860035a1e482325c8b924eb5ec7b81c1cc92980847da7016a582acdf82f'
 const WRAPPER_INTERFACE = new utils.Interface([`function withdraw(uint256 _amount) external`])
 
 class ERC20WrapperService {
+  public readonly address: string
   public readonly contract: Contract
+  public readonly positionId: BigNumber
 
-  constructor(address: string, provider: any) {
+  constructor(address: string, positionId: BigNumber, provider: any) {
     this.contract = new Contract(address, WRAPPER_INTERFACE, provider).connect(provider.getSigner())
+    this.positionId = positionId
+    this.address = address
   }
 
   static predictAddress = (factoryAddress: string, positionId: BigNumber): string =>

--- a/app/src/services/erc20_wrapper.ts
+++ b/app/src/services/erc20_wrapper.ts
@@ -1,0 +1,22 @@
+import { Contract, utils } from 'ethers'
+import { BigNumber } from 'ethers/utils'
+
+const WRAPPER_INTERFACE = new utils.Interface([`function withdraw(uint256 _amount) external`])
+
+class ERC20WrapperService {
+  public readonly contract: Contract
+
+  constructor(address: string, provider: any) {
+    this.contract = new Contract(address, WRAPPER_INTERFACE, provider).connect(provider.getSigner())
+  }
+
+  get address(): string {
+    return this.contract.address
+  }
+
+  static encodeWithdraw = (amount: BigNumber): string => {
+    return WRAPPER_INTERFACE.functions.withdraw.encode([amount])
+  }
+}
+
+export { ERC20WrapperService }

--- a/app/src/services/erc20_wrapper.ts
+++ b/app/src/services/erc20_wrapper.ts
@@ -1,6 +1,7 @@
 import { Contract, utils } from 'ethers'
-import { BigNumber } from 'ethers/utils'
+import { BigNumber, getCreate2Address, solidityKeccak256, solidityPack } from 'ethers/utils'
 
+const INIT_CODE_HASH = '0x5058e67e4d72ed90876a53ce32f1bdd8b0f8a4f56cce190f0f25fa4dbe3e1160'
 const WRAPPER_INTERFACE = new utils.Interface([`function withdraw(uint256 _amount) external`])
 
 class ERC20WrapperService {
@@ -10,9 +11,12 @@ class ERC20WrapperService {
     this.contract = new Contract(address, WRAPPER_INTERFACE, provider).connect(provider.getSigner())
   }
 
-  get address(): string {
-    return this.contract.address
-  }
+  static predictAddress = (factoryAddress: string, positionId: BigNumber): string =>
+    getCreate2Address({
+      from: factoryAddress,
+      initCodeHash: INIT_CODE_HASH,
+      salt: solidityKeccak256(['bytes'], [solidityPack(['uint256'], [positionId])]),
+    })
 
   static encodeWithdraw = (amount: BigNumber): string => {
     return WRAPPER_INTERFACE.functions.withdraw.encode([amount])

--- a/app/src/services/erc20_wrapper_factory.ts
+++ b/app/src/services/erc20_wrapper_factory.ts
@@ -3,7 +3,6 @@ import { BigNumber } from 'ethers/utils'
 
 const WRAPPER_FACTORY_INTERFACE = new utils.Interface([
   `function createWrapper(string _name, string _symbol, uint256 _positionId) external`,
-  `function wrapperForPosition(uint256 _positionId) external view returns(address)`,
 ])
 
 class ERC20WrapperFactoryService {
@@ -15,10 +14,6 @@ class ERC20WrapperFactoryService {
 
   get address(): string {
     return this.contract.address
-  }
-
-  async wrapperForPosition(positionId: BigNumber): Promise<string> {
-    return await this.contract.wrapperForPosition(positionId)
   }
 
   static encodeCreateWrapperCall = (name: string, symbol: string, positionId: BigNumber): string => {

--- a/app/src/services/erc20_wrapper_factory.ts
+++ b/app/src/services/erc20_wrapper_factory.ts
@@ -1,8 +1,12 @@
 import { Contract, utils } from 'ethers'
 import { BigNumber } from 'ethers/utils'
 
+import { ConditionalTokenService } from './conditional_token'
+import { MarketMakerService } from './market_maker'
+
 const WRAPPER_FACTORY_INTERFACE = new utils.Interface([
   `function createWrapper(string _name, string _symbol, uint256 _positionId) external`,
+  `function wrappedPosition(uint256 _position) public view returns(bool)`,
 ])
 
 class ERC20WrapperFactoryService {
@@ -18,6 +22,20 @@ class ERC20WrapperFactoryService {
 
   static encodeCreateWrapperCall = (name: string, symbol: string, positionId: BigNumber): string => {
     return WRAPPER_FACTORY_INTERFACE.functions.createWrapper.encode([name, symbol, positionId])
+  }
+
+  marketWrapped = async (
+    conditionalTokens: ConditionalTokenService,
+    marketMaker: MarketMakerService,
+    outcomesAmount: number,
+  ): Promise<boolean> => {
+    const collateral = await marketMaker.getCollateralToken()
+    for (let i = 0; i < outcomesAmount; i++) {
+      const collectionId = await conditionalTokens.getCollectionIdForOutcome(await marketMaker.getConditionId(), 1 << i)
+      const positionId = await conditionalTokens.getPositionId(collateral, collectionId)
+      if (!(await this.contract.wrappedPosition(positionId))) return false
+    }
+    return true
   }
 }
 

--- a/app/src/services/erc20_wrapper_factory.ts
+++ b/app/src/services/erc20_wrapper_factory.ts
@@ -1,0 +1,28 @@
+import { Contract, utils } from 'ethers'
+
+const WRAPPER_FACTORY_INTERFACE = new utils.Interface([
+  `function createWrapper(string _name, string _symbol, uint256 _positionId) external`,
+  `function wrapperForPosition(uint256 _positionId) external view returns(address)`,
+])
+
+class ERC20WrapperFactoryService {
+  public readonly contract: Contract
+
+  constructor(address: string, provider: any) {
+    this.contract = new Contract(address, WRAPPER_FACTORY_INTERFACE, provider)
+  }
+
+  get address(): string {
+    return this.contract.address
+  }
+
+  async wrapperForPosition(positionId: number): Promise<string> {
+    return await this.contract.wrapperForPosition(positionId)
+  }
+
+  static encodeCreateWrapperCall = (name: string, symbol: string, positionId: number): string => {
+    return WRAPPER_FACTORY_INTERFACE.functions.createWrapper.encode([name, symbol, positionId])
+  }
+}
+
+export { ERC20WrapperFactoryService }

--- a/app/src/services/erc20_wrapper_factory.ts
+++ b/app/src/services/erc20_wrapper_factory.ts
@@ -1,4 +1,5 @@
 import { Contract, utils } from 'ethers'
+import { BigNumber } from 'ethers/utils'
 
 const WRAPPER_FACTORY_INTERFACE = new utils.Interface([
   `function createWrapper(string _name, string _symbol, uint256 _positionId) external`,
@@ -16,11 +17,11 @@ class ERC20WrapperFactoryService {
     return this.contract.address
   }
 
-  async wrapperForPosition(positionId: number): Promise<string> {
+  async wrapperForPosition(positionId: BigNumber): Promise<string> {
     return await this.contract.wrapperForPosition(positionId)
   }
 
-  static encodeCreateWrapperCall = (name: string, symbol: string, positionId: number): string => {
+  static encodeCreateWrapperCall = (name: string, symbol: string, positionId: BigNumber): string => {
     return WRAPPER_FACTORY_INTERFACE.functions.createWrapper.encode([name, symbol, positionId])
   }
 }

--- a/app/src/services/market_maker.ts
+++ b/app/src/services/market_maker.ts
@@ -7,6 +7,7 @@ import { Market, MarketStatus, MarketWithExtraData } from '../util/types'
 
 import { ConditionalTokenService } from './conditional_token'
 import { ERC20Service } from './erc20'
+import { ERC20WrapperService } from './erc20_wrapper'
 import { ERC20WrapperFactoryService } from './erc20_wrapper_factory'
 import { RealitioService } from './realitio'
 
@@ -167,8 +168,11 @@ class MarketMakerService {
         `Balance information :: Collection ID for outcome index ${i} and condition id ${conditionId} : ${collectionId}`,
       )
       const positionIdForCollectionId = await this.conditionalTokens.getPositionId(collateralTokenAddress, collectionId)
-      const erc20WrapperAddress = await this.erc20WrapperFactoryService.wrapperForPosition(positionIdForCollectionId)
-      const erc20Wrapper = new ERC20Service(this.provider, ownerAddress, erc20WrapperAddress)
+      const erc20Wrapper = new ERC20Service(
+        this.provider,
+        ownerAddress,
+        ERC20WrapperService.predictAddress(this.erc20WrapperFactoryService.address, positionIdForCollectionId),
+      )
       const balance = await erc20Wrapper.balanceOf(ownerAddress)
       logger.debug(`Balance information :: Balance ${balance.toString()}`)
       balances.push(balance)
@@ -192,8 +196,11 @@ class MarketMakerService {
         `Balance information :: Collection ID for outcome index ${i} and condition id ${conditionId} : ${collectionId}`,
       )
       const positionIdForCollectionId = await this.conditionalTokens.getPositionId(collateralTokenAddress, collectionId)
-      const erc20WrapperAddress = await this.erc20WrapperFactoryService.wrapperForPosition(positionIdForCollectionId)
-      const erc20Wrapper = new ERC20Service(this.provider, ownerAddress, erc20WrapperAddress)
+      const erc20Wrapper = new ERC20Service(
+        this.provider,
+        ownerAddress,
+        ERC20WrapperService.predictAddress(this.erc20WrapperFactoryService.address, positionIdForCollectionId),
+      )
       const balance = await erc20Wrapper.balanceOfByBlock(ownerAddress, block.blockNumber)
 
       logger.debug(`Balance information :: Balance ${balance.toString()}`)

--- a/app/src/services/market_maker_factory.ts
+++ b/app/src/services/market_maker_factory.ts
@@ -7,6 +7,7 @@ import { getLogger } from '../util/logger'
 import { Log, Market, MarketWithExtraData } from '../util/types'
 
 import { ConditionalTokenService } from './conditional_token'
+import { ERC20WrapperFactoryService } from './erc20_wrapper_factory'
 import { MarketMakerService } from './market_maker'
 import { RealitioService } from './realitio'
 
@@ -162,6 +163,7 @@ class MarketMakerFactoryService {
   getMarketsWithExtraData = async (
     { from, to }: GetMarketsOptions,
     conditionalTokens: ConditionalTokenService,
+    erc20WrapperFactory: ERC20WrapperFactoryService,
     realitio: RealitioService,
   ): Promise<MarketWithExtraData[]> => {
     const markets = await this.getMarkets({ from, to })
@@ -171,6 +173,7 @@ class MarketMakerFactoryService {
         const marketMaker = new MarketMakerService(
           market.address,
           conditionalTokens,
+          erc20WrapperFactory,
           realitio,
           this.provider,
           this.signerAddress,

--- a/app/src/util/networks.ts
+++ b/app/src/util/networks.ts
@@ -166,7 +166,7 @@ const networks: { [K in NetworkId]: Network } = {
       realitioScalarAdapter: '0x0e8Db8caD541C0Bf5b611636e81fEc0828bc7902',
       marketMakerFactory: '0x0fB4340432e56c014fa96286de17222822a9281b',
       conditionalTokens: '0x36bede640D19981A82090519bC1626249984c908',
-      erc20WrapperFactory: '0xBF689CE7Dad8957113637A6b05a665c29f4F991b',
+      erc20WrapperFactory: '0x06eC7651dA53b805438d3292E9Fa6ae3CdED8B61',
       oracle: '0x17174dC1b62add32a1DE477A357e75b0dcDEed6E',
       klerosBadge: '0x0000000000000000000000000000000000000000',
       klerosTokenView: '0x0000000000000000000000000000000000000000',

--- a/app/src/util/networks.ts
+++ b/app/src/util/networks.ts
@@ -166,7 +166,7 @@ const networks: { [K in NetworkId]: Network } = {
       realitioScalarAdapter: '0x0e8Db8caD541C0Bf5b611636e81fEc0828bc7902',
       marketMakerFactory: '0x0fB4340432e56c014fa96286de17222822a9281b',
       conditionalTokens: '0x36bede640D19981A82090519bC1626249984c908',
-      erc20WrapperFactory: '0x1c8d24dC0d3273518161800C9E6EF5094A913DE3',
+      erc20WrapperFactory: '0xBF689CE7Dad8957113637A6b05a665c29f4F991b',
       oracle: '0x17174dC1b62add32a1DE477A357e75b0dcDEed6E',
       klerosBadge: '0x0000000000000000000000000000000000000000',
       klerosTokenView: '0x0000000000000000000000000000000000000000',

--- a/app/src/util/networks.ts
+++ b/app/src/util/networks.ts
@@ -166,7 +166,7 @@ const networks: { [K in NetworkId]: Network } = {
       realitioScalarAdapter: '0x0e8Db8caD541C0Bf5b611636e81fEc0828bc7902',
       marketMakerFactory: '0x0fB4340432e56c014fa96286de17222822a9281b',
       conditionalTokens: '0x36bede640D19981A82090519bC1626249984c908',
-      erc20WrapperFactory: '0xe2a7e299c047D876AbE49c6e4B5525c661771caa',
+      erc20WrapperFactory: '0x1c8d24dC0d3273518161800C9E6EF5094A913DE3',
       oracle: '0x17174dC1b62add32a1DE477A357e75b0dcDEed6E',
       klerosBadge: '0x0000000000000000000000000000000000000000',
       klerosTokenView: '0x0000000000000000000000000000000000000000',

--- a/app/src/util/networks.ts
+++ b/app/src/util/networks.ts
@@ -166,7 +166,7 @@ const networks: { [K in NetworkId]: Network } = {
       realitioScalarAdapter: '0x0e8Db8caD541C0Bf5b611636e81fEc0828bc7902',
       marketMakerFactory: '0x0fB4340432e56c014fa96286de17222822a9281b',
       conditionalTokens: '0x36bede640D19981A82090519bC1626249984c908',
-      erc20WrapperFactory: '0xf4E11Fd192F1BD7F38bb8E9CC627c5E3017fBad3',
+      erc20WrapperFactory: '0xe2a7e299c047D876AbE49c6e4B5525c661771caa',
       oracle: '0x17174dC1b62add32a1DE477A357e75b0dcDEed6E',
       klerosBadge: '0x0000000000000000000000000000000000000000',
       klerosTokenView: '0x0000000000000000000000000000000000000000',

--- a/app/src/util/networks.ts
+++ b/app/src/util/networks.ts
@@ -166,7 +166,7 @@ const networks: { [K in NetworkId]: Network } = {
       realitioScalarAdapter: '0x0e8Db8caD541C0Bf5b611636e81fEc0828bc7902',
       marketMakerFactory: '0x0fB4340432e56c014fa96286de17222822a9281b',
       conditionalTokens: '0x36bede640D19981A82090519bC1626249984c908',
-      erc20WrapperFactory: '0x47C8bf756c91eB059581DaFEeAaf2eac2a54d5bb',
+      erc20WrapperFactory: '0xf4E11Fd192F1BD7F38bb8E9CC627c5E3017fBad3',
       oracle: '0x17174dC1b62add32a1DE477A357e75b0dcDEed6E',
       klerosBadge: '0x0000000000000000000000000000000000000000',
       klerosTokenView: '0x0000000000000000000000000000000000000000',

--- a/app/src/util/networks.ts
+++ b/app/src/util/networks.ts
@@ -63,6 +63,7 @@ interface Network {
     realitio: string
     realitioScalarAdapter: string
     marketMakerFactory: string
+    erc20WrapperFactory: string
     conditionalTokens: string
     oracle: string
     klerosBadge: string
@@ -118,6 +119,7 @@ const networks: { [K in NetworkId]: Network } = {
       realitioScalarAdapter: '0xaa548EfBb0972e0c4b9551dcCfb6B787A1B90082',
       marketMakerFactory: '0x89023DEb1d9a9a62fF3A5ca8F23Be8d87A576220',
       conditionalTokens: '0xC59b0e4De5F1248C1140964E0fF287B192407E0C',
+      erc20WrapperFactory: '0x0000000000000000000000000000000000000000',
       oracle: '0x0e414d014a77971f4eaa22ab58e6d84d16ea838e',
       klerosBadge: '0xcb4aae35333193232421e86cd2e9b6c91f3b125f',
       klerosTokenView: '0xf9b9b5440340123b21bff1ddafe1ad6feb9d6e7f',
@@ -164,6 +166,7 @@ const networks: { [K in NetworkId]: Network } = {
       realitioScalarAdapter: '0x0e8Db8caD541C0Bf5b611636e81fEc0828bc7902',
       marketMakerFactory: '0x0fB4340432e56c014fa96286de17222822a9281b',
       conditionalTokens: '0x36bede640D19981A82090519bC1626249984c908',
+      erc20WrapperFactory: '0x47C8bf756c91eB059581DaFEeAaf2eac2a54d5bb',
       oracle: '0x17174dC1b62add32a1DE477A357e75b0dcDEed6E',
       klerosBadge: '0x0000000000000000000000000000000000000000',
       klerosTokenView: '0x0000000000000000000000000000000000000000',
@@ -210,6 +213,7 @@ const networks: { [K in NetworkId]: Network } = {
       realitioScalarAdapter: '0x1D369EEC97cF2E62c8DBB804b3998Bf15bcb67dB',
       marketMakerFactory: '0x2fb8cc057946DCFA32D8eA8115A1Dd630f6efea5',
       conditionalTokens: '0x0Db8C35045a830DC7F2A4dd87ef90e7A9Cd0534f',
+      erc20WrapperFactory: '0x0000000000000000000000000000000000000000',
       oracle: '0x9E6bd63aEbFb2E858B6111cea9C389f7664F7108',
       klerosBadge: '0x0000000000000000000000000000000000000000',
       klerosTokenView: '0x0000000000000000000000000000000000000000',
@@ -259,6 +263,7 @@ const networks: { [K in NetworkId]: Network } = {
       realitioScalarAdapter: '0xcA75aaC320089c9fb077E86857fF6e954Df06a6B',
       marketMakerFactory: '0x9083A2B699c0a4AD06F63580BDE2635d26a3eeF0',
       conditionalTokens: '0xCeAfDD6bc0bEF976fdCd1112955828E00543c0Ce',
+      erc20WrapperFactory: '0x0000000000000000000000000000000000000000',
       oracle: '0xAB16D643bA051C11962DA645f74632d3130c81E2',
       klerosBadge: '0x0000000000000000000000000000000000000000',
       klerosTokenView: '0x0000000000000000000000000000000000000000',

--- a/app/src/util/tools.ts
+++ b/app/src/util/tools.ts
@@ -376,7 +376,7 @@ export const getSharesInBaseToken = (
   displayCollateral: Token,
 ): BalanceItem[] => {
   const displayBalances = balances.map(function(bal) {
-    const baseTokenShares = compoundService.calculateCTokenToBaseExchange(displayCollateral, bal.shares)
+    const baseTokenShares = compoundService.calculateCTokenToBaseExchange(displayCollateral, bal.totalShares)
     const newBalanceObject = Object.assign({}, bal, {
       shares: baseTokenShares,
     })

--- a/app/src/util/types.ts
+++ b/app/src/util/types.ts
@@ -194,6 +194,7 @@ export interface MarketData {
   collateral: Token
   userInputCollateral: Token
   arbitratorsCustom: Arbitrator[]
+  baseERC20TokenSymbol: string
   categoriesCustom: string[]
   compoundInterestRate: string
   question: string

--- a/app/src/util/types.ts
+++ b/app/src/util/types.ts
@@ -46,7 +46,9 @@ export interface BalanceItem {
   probability: number
   currentPrice: number
   currentDisplayPrice?: number
-  shares: BigNumber
+  erc20Shares: BigNumber
+  erc1155Shares: BigNumber
+  totalShares: BigNumber
   payout: Big
   holdings: BigNumber
 }

--- a/app/src/util/types.ts
+++ b/app/src/util/types.ts
@@ -287,6 +287,7 @@ export interface MarketMakerData {
   userInputCollateral: Token | null
   creator: string
   fee: BigNumber
+  conditionId: string
   isConditionResolved: boolean
   isQuestionFinalized: boolean
   collateralVolume: BigNumber


### PR DESCRIPTION
Draft PR implementing ERC20 wrapping of ERC1155 position tokens. Wrappers are position-specific and deployed when a market is created. When buying shares, the ERC1155 tokens are wrapped and the user gets back a ERC20 representation. Inversely, when selling, the ERC20 tokens are taken by the user's Gnosis safe proxy and unwrapped before acting.

The transition from non-wrapped to wrapped market should be smooth. If a market gets upgraded after getting created (a market is defined as wrapped when someone deploys wrapping contracts for each of the available positions) and the user (or its proxy contract) still holds ERC1155, he's asked to upgrade his tokens to ERC20 before resuming activity.

There's a specific formula to name the ERC20 tokens (which currently results in lenghty names/symbols), in where a user is asked for a base name when creating a market, and names for each position are automatically generated from that.

The feature is currently only enabled on Rinkeby through the use of [these contracts](https://github.com/luzzif/erc1155-to-erc20-wrapper-contracts).