### PR TITLE
set max width of outcomes on list view

### DIFF
--- a/app/src/components/market/common/list_item/index.tsx
+++ b/app/src/components/market/common/list_item/index.tsx
@@ -65,6 +65,10 @@ const Outcome = styled.span`
   color: ${props => props.theme.colors.primaryLight};
   margin-left: 8px;
   font-weight: 500;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 200px;
 `
 
 const Separator = styled.span`


### PR DESCRIPTION
Outcomes can be quite long which can mess up the layout in the market list view:

PR is a change from:
<img width="580" alt="Screen Shot 2021-04-26 at 4 17 10 pm" src="https://user-images.githubusercontent.com/72715177/116037357-50ca8480-a6ab-11eb-932c-3720c631a55f.png">

To:
<img width="579" alt="Screen Shot 2021-04-26 at 4 17 21 pm" src="https://user-images.githubusercontent.com/72715177/116037333-490ae000-a6ab-11eb-8d81-7df104fce039.png">

Users can click through to see the full outcome info if they are interested.