### PR TITLE
fix token loading in compound markets

### DIFF
--- a/app/src/components/market/common/currency_selector/index.tsx
+++ b/app/src/components/market/common/currency_selector/index.tsx
@@ -89,11 +89,13 @@ export const CurrencySelector: React.FC<Props> = props => {
     currentItem = 0
   }
 
+  const lowerCaseFilters = filters.map(address => address.toLowerCase())
+
   tokens
     .filter(({ address }) =>
-      filters.length === 0 || negativeFilter
-        ? filters.indexOf(address.toLowerCase()) === -1
-        : filters.indexOf(address.toLowerCase()) >= 0,
+      lowerCaseFilters.length === 0 || negativeFilter
+        ? lowerCaseFilters.indexOf(address.toLowerCase()) === -1
+        : lowerCaseFilters.indexOf(address.toLowerCase()) >= 0,
     )
     .forEach(({ address, balance: tokenBalance, decimals, image, symbol }, index) => {
       const selected = currency && currency.toLowerCase() === address.toLowerCase()

--- a/app/src/components/market/sections/market_buy/market_buy.tsx
+++ b/app/src/components/market/sections/market_buy/market_buy.tsx
@@ -340,9 +340,9 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
 
   if (collateralSymbol in CompoundTokenType) {
     if (baseCollateral.symbol.toLowerCase() === 'eth') {
-      currencyFilters = [collateral.address, pseudoNativeAssetAddress.toLowerCase()]
+      currencyFilters = [collateral.address.toLowerCase(), pseudoNativeAssetAddress.toLowerCase()]
     } else {
-      currencyFilters = [collateral.address, baseCollateral.address]
+      currencyFilters = [collateral.address.toLowerCase(), baseCollateral.address.toLowerCase()]
     }
   }
 

--- a/app/src/components/market/sections/market_buy/scalar_market_buy.tsx
+++ b/app/src/components/market/sections/market_buy/scalar_market_buy.tsx
@@ -361,9 +361,9 @@ export const ScalarMarketBuy = (props: Props) => {
   const currencySelectorIsDisabled = relay ? true : currencyFilters.length ? false : true
   if (collateralSymbol in CompoundTokenType) {
     if (baseCollateral.address === pseudoNativeAssetAddress) {
-      currencyFilters = [collateral.address, pseudoNativeAssetAddress.toLowerCase()]
+      currencyFilters = [collateral.address.toLowerCase(), pseudoNativeAssetAddress.toLowerCase()]
     } else {
-      currencyFilters = [collateral.address, baseCollateral.address]
+      currencyFilters = [collateral.address.toLowerCase(), baseCollateral.address.toLowerCase()]
     }
   }
 


### PR DESCRIPTION
PR makes sure token filters are lowercase.

before:
<img width="281" alt="Screen Shot 2021-04-27 at 5 02 07 pm" src="https://user-images.githubusercontent.com/72715177/116199306-5216b280-a77a-11eb-8acb-d6b26b03b606.png">

after:
<img width="282" alt="Screen Shot 2021-04-27 at 5 01 41 pm" src="https://user-images.githubusercontent.com/72715177/116199323-56db6680-a77a-11eb-88f7-eab89739e2ea.png">
