### PR TITLE
fix/1880

### DIFF
--- a/app/src/components/common/layout/header/index.tsx
+++ b/app/src/components/common/layout/header/index.tsx
@@ -269,7 +269,7 @@ const HeaderContainer: React.FC = (props: any) => {
             </>
           )}
 
-          {(networkId === networkIds.MAINNET || relay) && (
+          {((networkId === networkIds.MAINNET && context.rawWeb3Context.connectorName !== 'Safe') || relay) && (
             <HeaderDropdown
               currentItem={networkDropdownItems.length + 1}
               disableDirty

--- a/app/src/components/common/switch_network_modal/index.tsx
+++ b/app/src/components/common/switch_network_modal/index.tsx
@@ -112,9 +112,9 @@ export const SwitchNetworkModal: React.FC<Props> = props => {
 
   const setLocation = (network: string) => {
     if (network === networks.mainnet) {
-      location.assign(`https://${MAINNET_LOCATION}`)
+      location.assign(`http://${MAINNET_LOCATION}`)
     } else if (network === networks.xdai) {
-      location.assign(`https://${XDAI_LOCATION}`)
+      location.assign(`http://${XDAI_LOCATION}`)
     }
   }
 

--- a/app/src/components/common/switch_network_modal/index.tsx
+++ b/app/src/components/common/switch_network_modal/index.tsx
@@ -112,9 +112,9 @@ export const SwitchNetworkModal: React.FC<Props> = props => {
 
   const setLocation = (network: string) => {
     if (network === networks.mainnet) {
-      location.assign(`http://${MAINNET_LOCATION}`)
+      location.assign(`https://${MAINNET_LOCATION}`)
     } else if (network === networks.xdai) {
-      location.assign(`http://${XDAI_LOCATION}`)
+      location.assign(`https://${XDAI_LOCATION}`)
     }
   }
 

--- a/app/src/components/main/index.tsx
+++ b/app/src/components/main/index.tsx
@@ -40,11 +40,11 @@ export const Main: React.FC = () => {
   useEffect(() => {
     if (networkId) {
       setWrongNetwork(
-        (location.host === MAINNET_LOCATION && XDAI_NETWORKS.includes(networkId)) ||
-          (location.host === XDAI_LOCATION && MAIN_NETWORKS.includes(networkId)),
+        (context.connectorName !== 'Safe' && location.host === MAINNET_LOCATION && XDAI_NETWORKS.includes(networkId)) ||
+          (context.connectorName !== 'Safe' && location.host === XDAI_LOCATION && MAIN_NETWORKS.includes(networkId)),
       )
     }
-  }, [networkId])
+  }, [networkId, context.connectorName])
 
   return (
     <>

--- a/app/src/hooks/connectedWeb3.tsx
+++ b/app/src/hooks/connectedWeb3.tsx
@@ -120,7 +120,12 @@ export const ConnectedWeb3: React.FC<Props> = (props: Props) => {
     return null
   }
 
-  const { address, isRelay, netId, provider } = getRelayProvider(relay, networkId, library, account)
+  const { address, isRelay, netId, provider } = getRelayProvider(
+    relay && context.connectorName !== 'Safe',
+    networkId,
+    library,
+    account,
+  )
 
   const value = {
     account: address || null,


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/1880

When using https://xdai.gnosis-safe.io/ to load https://omen.eth.link/ as a safe app, you get presented with "Continue with xDai" button. If you click it you get hit with the following error:

`Mixed Content: The page at '.../?appUrl=https://omen.eth.link/' was loaded over HTTPS, but requested an insecure frame 'http://xdai.omen.eth.link/'. This request has been blocked; the content must be served over HTTPS.`

Likely something to do with greater security when Omen is running in an iframe as a safe app.

PR disables wrong network errors for safe apps, allowing use of xdai on https://omen.eth.link/ for safe apps only.

PR also disables relay toggle for safe apps on mainnet. Safe app users must either directly use mainnet or directly use xdai.



