### PR TITLE
fix/1916

### DIFF
--- a/app/src/components/market/common/market_scale/index.tsx
+++ b/app/src/components/market/common/market_scale/index.tsx
@@ -19,6 +19,7 @@ import {
   AdditionalSharesType,
   BalanceItem,
   CompoundTokenType,
+  INVALID_ANSWER_ID,
   LiquidityObject,
   LiquidityType,
   MarketDetailsTab,
@@ -634,10 +635,11 @@ export const MarketScale: React.FC<Props> = (props: Props) => {
       subtitle: 'Bonded',
     },
     {
-      title:
-        currentAnswer && collateral
-          ? `${formatBigNumber(new BigNumber(currentAnswer), STANDARD_DECIMALS)} ${unit}`
-          : '-',
+      title: currentAnswer
+        ? currentAnswer === INVALID_ANSWER_ID
+          ? 'Invalid'
+          : `${formatBigNumber(new BigNumber(currentAnswer), STANDARD_DECIMALS)} ${unit}`
+        : '-',
       subtitle: isBonded ? 'Pending Outcome' : 'Final Outcome',
     },
   ]


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/1916

Test on Rinkeby:

[This market](http://localhost:3000/#/0xe33fe6be741b524d27b2ede079a7e92c8184a038) should display an invalid final outcome
[This market](http://localhost:3000/#/0xe24f62046b73ebb42b8ef19cb186eea1131e1030) should display a normal final outcome