### PR TITLE
fix/1930 

### DIFF
--- a/app/src/components/market/sections/market_buy/market_buy.tsx
+++ b/app/src/components/market/sections/market_buy/market_buy.tsx
@@ -226,6 +226,12 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
           useBaseToken = true
         }
       }
+
+      const inputCollateral =
+        collateral.symbol !== displayCollateral.symbol && collateral.symbol === nativeAsset.symbol
+          ? displayCollateral
+          : collateral
+
       const sharesAmount = formatBigNumber(displayTradedShares, baseCollateral.decimals, baseCollateral.decimals)
       setTweet('')
       setStatus(Status.Loading)
@@ -233,9 +239,10 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
       setTxState(TransactionStep.waitingConfirmation)
       setIsTransactionProcessing(true)
       setIsTransactionModalOpen(true)
+
       await cpk.buyOutcomes({
         amount: inputAmount,
-        collateral,
+        collateral: inputCollateral,
         compoundService,
         marketMaker,
         outcomeIndex,
@@ -326,12 +333,11 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
     (status !== Status.Ready && status !== Status.Error) ||
     amount?.isZero() ||
     (!cpk?.isSafeApp &&
-      collateral.address !== pseudoNativeAssetAddress &&
       displayCollateral.address !== pseudoNativeAssetAddress &&
       hasEnoughAllowance !== Ternary.True) ||
     amountError !== null ||
     isNegativeAmount ||
-    (!isUpdated && collateral.address === pseudoNativeAssetAddress)
+    (!isUpdated && displayCollateral.address === pseudoNativeAssetAddress)
 
   let currencyFilters =
     collateral.address === wrapToken.address || collateral.address === pseudoNativeAssetAddress

--- a/app/src/components/market/sections/market_buy/scalar_market_buy.tsx
+++ b/app/src/components/market/sections/market_buy/scalar_market_buy.tsx
@@ -289,11 +289,11 @@ export const ScalarMarketBuy = (props: Props) => {
     (status !== Status.Ready && status !== Status.Error) ||
     amount.isZero() ||
     (!cpk?.isSafeApp &&
-      collateral.address !== pseudoNativeAssetAddress &&
       displayCollateral.address !== pseudoNativeAssetAddress &&
       hasEnoughAllowance !== Ternary.True) ||
     amountError !== null ||
-    isNegativeAmount
+    isNegativeAmount ||
+    (!isUpdated && displayCollateral.address === pseudoNativeAssetAddress)
 
   const finish = async () => {
     const outcomeIndex = positionIndex
@@ -311,6 +311,11 @@ export const ScalarMarketBuy = (props: Props) => {
           inputAmount = compoundService.calculateCTokenToBaseExchange(baseCollateral, amount)
         }
       }
+      const inputCollateral =
+        collateral.symbol !== displayCollateral.symbol && collateral.symbol === nativeAsset.symbol
+          ? displayCollateral
+          : collateral
+
       const sharesAmount = formatBigNumber(displayTradedShares, baseCollateral.decimals, baseCollateral.decimals)
       setTweet('')
       setStatus(Status.Loading)
@@ -320,7 +325,7 @@ export const ScalarMarketBuy = (props: Props) => {
 
       await cpk.buyOutcomes({
         amount: inputAmount,
-        collateral,
+        collateral: inputCollateral,
         compoundService,
         outcomeIndex,
         marketMaker,

--- a/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
@@ -280,10 +280,16 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
       setTxState(TransactionStep.waitingConfirmation)
       setIsTransactionProcessing(true)
       setIsTransactionModalOpen(true)
+
+      const inputCollateral =
+        collateral.symbol !== displayCollateral.symbol && collateral.symbol === nativeAsset.symbol
+          ? displayCollateral
+          : collateral
+
       await cpk.addFunding({
         amount: amountToFundNormalized || Zero,
         compoundService,
-        collateral,
+        collateral: inputCollateral,
         marketMaker,
         setTxHash,
         setTxState,
@@ -413,17 +419,19 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
   const disableDepositButton =
     !amountToFund ||
     amountToFund?.isZero() ||
-    (!cpk?.isSafeApp && collateral.address !== pseudoNativeAssetAddress && hasEnoughAllowance !== Ternary.True) ||
+    (!cpk?.isSafeApp &&
+      displayCollateral.address !== pseudoNativeAssetAddress &&
+      hasEnoughAllowance !== Ternary.True) ||
     collateralAmountError !== null ||
     currentDate > resolutionDate ||
     isNegativeAmountToFund
 
   const setDisplayCollateralAmountToFund = (value: BigNumber) => {
-    if (collateral.address === displayCollateral.address) {
-      setAmountToFund(value)
-    } else if (compoundService) {
+    if (compoundService) {
       const baseAmount = compoundService.calculateBaseToCTokenExchange(displayCollateral, value)
       setAmountToFund(baseAmount)
+    } else {
+      setAmountToFund(value)
     }
     setAmountToFundNormalized(value)
   }

--- a/app/src/components/market/sections/market_pooling/scalar_market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/scalar_market_pool_liquidity.tsx
@@ -274,10 +274,15 @@ export const ScalarMarketPoolLiquidity = (props: Props) => {
       setTxState(TransactionStep.waitingConfirmation)
       setIsTransactionModalOpen(true)
 
+      const inputCollateral =
+        collateral.symbol !== displayCollateral.symbol && collateral.symbol === nativeAsset.symbol
+          ? displayCollateral
+          : collateral
+
       await cpk.addFunding({
         amount: amountToFundNormalized || Zero,
         compoundService,
-        collateral,
+        collateral: inputCollateral,
         marketMaker,
         setTxHash,
         setTxState,
@@ -334,6 +339,7 @@ export const ScalarMarketPoolLiquidity = (props: Props) => {
           useBaseToken = true
         }
       }
+
       await cpk.removeFunding({
         amountToMerge: depositedTokens,
         collateralAddress,
@@ -388,7 +394,9 @@ export const ScalarMarketPoolLiquidity = (props: Props) => {
   const disableDepositButton =
     !amountToFund ||
     amountToFund?.isZero() ||
-    (!cpk?.isSafeApp && collateral.address !== pseudoNativeAssetAddress && hasEnoughAllowance !== Ternary.True) ||
+    (!cpk?.isSafeApp &&
+      displayCollateral.address !== pseudoNativeAssetAddress &&
+      hasEnoughAllowance !== Ternary.True) ||
     collateralAmountError !== null ||
     currentDate > resolutionDate ||
     isNegativeAmountToFund
@@ -451,11 +459,11 @@ export const ScalarMarketPoolLiquidity = (props: Props) => {
   }
 
   const setDisplayCollateralAmountToFund = (value: BigNumber) => {
-    if (collateral.address === displayCollateral.address) {
-      setAmountToFund(value)
-    } else if (compoundService) {
+    if (compoundService) {
       const baseAmount = compoundService.calculateBaseToCTokenExchange(displayCollateral, value)
       setAmountToFund(baseAmount)
+    } else {
+      setAmountToFund(value)
     }
     setAmountToFundNormalized(value)
   }


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/1930 

Rinkeby testing guide:

Please double check your transactions on etherscan to make sure you are spending either WETH or ETH. You can send some ETH to `0xc778417e063141139fce010982780140aa0cd5ab` to obtain WETH if you don't have any.

[Scalar Market](http://localhost:3000/#/0x88a6c09e343b88c1a1c6b0cd62f9f4924f7fbc68)
- [ ] Buy with WETH
- [ ] Buy with ETH
- [ ] Fund with ETH
- [ ] Fund with WETH

[Categorical Market](http://localhost:3000/#/0xb4277c368b817db02bab8b684c9bfe10200461f7)
- [ ] Buy with WETH
- [ ] Buy with ETH
- [ ] Fund with ETH
- [ ] Fund with WETH
