### PR TITLE
Bump version to include patch number

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "1.3",
+  "version": "1.3.0",
   "private": true,
   "engines": {
     "node": ">=v12.13.0 <13"


### PR DESCRIPTION
It looks like npm doesn't like it if we don't include the patch number in the version number. Going forward, since we don't do patches with our current deploy process, we should simply keep it as 0, e.g. `1.3.0, 1.4.0, 1.5.0`.