### PR TITLE
refactor: remove compound logic from market buy

### DIFF
--- a/app/src/components/market/common/currency_selector/index.tsx
+++ b/app/src/components/market/common/currency_selector/index.tsx
@@ -33,7 +33,7 @@ interface Props {
   context: ConnectedWeb3Context
   disabled?: boolean
   filters?: Array<string>
-  onSelect: (currency: Token | null) => void
+  onSelect?: (currency: Token | null) => void
   balance?: string
   placeholder?: Maybe<string>
   addAll?: boolean
@@ -69,7 +69,7 @@ export const CurrencySelector: React.FC<Props> = props => {
 
   const onChange = (address: string) => {
     for (const token of tokens) {
-      if (token.address === address) {
+      if (token.address === address && onSelect) {
         onSelect(token)
       }
     }
@@ -81,7 +81,7 @@ export const CurrencySelector: React.FC<Props> = props => {
     currencyDropdownData.push({
       content: 'All',
       onClick: () => {
-        if (!disabled) {
+        if (!disabled && onSelect) {
           onSelect(null)
         }
       },

--- a/app/src/components/market/common/outcome_table/index.tsx
+++ b/app/src/components/market/common/outcome_table/index.tsx
@@ -5,9 +5,9 @@ import styled from 'styled-components'
 
 import { useConnectedWeb3Context, useSymbol } from '../../../../hooks'
 import { getOutcomeColor } from '../../../../theme/utils'
-import { getNativeAsset, getNativeCompoundAsset, getToken } from '../../../../util/networks'
-import { formatBigNumber, formatNumber, getBaseTokenForCToken, mulBN } from '../../../../util/tools'
-import { BalanceItem, BondItem, CompoundTokenType, OutcomeTableValue, Token } from '../../../../util/types'
+import { getNativeAsset } from '../../../../util/networks'
+import { formatBigNumber, formatNumber, mulBN } from '../../../../util/tools'
+import { BalanceItem, BondItem, OutcomeTableValue, Token } from '../../../../util/types'
 import { RadioInput, TD, THead, TR, Table } from '../../../common'
 import { BarDiagram } from '../bar_diagram_probabilities'
 import {
@@ -24,8 +24,6 @@ import { WinningBadge } from '../winning_badge'
 interface Props {
   balances: BalanceItem[]
   collateral: Token
-  displayBalances?: BalanceItem[]
-  displayCollateral?: Token
   disabledColumns?: OutcomeTableValue[]
   displayRadioSelection?: boolean
   outcomeHandleChange?: (e: number) => void
@@ -89,8 +87,6 @@ export const OutcomeTable = (props: Props) => {
     balances,
     collateral,
     disabledColumns = [],
-    displayCollateral = collateral,
-    displayBalances = balances,
     displayRadioSelection = true,
     newShares = null,
     outcomeHandleChange,
@@ -125,7 +121,7 @@ export const OutcomeTable = (props: Props) => {
   ]
 
   const TableCellsAlign = ['left', 'left', 'right', 'right', 'right', 'right', 'right']
-  const symbol = useSymbol(displayCollateral)
+  const symbol = useSymbol(collateral)
   const renderTableHeader = () => {
     return (
       <THead>
@@ -217,18 +213,6 @@ export const OutcomeTable = (props: Props) => {
   }
 
   const renderTableRow = (balanceItem: BalanceItem, outcomeIndex: number) => {
-    const currentCollateral = displayCollateral ? displayCollateral : collateral
-    let baseCollateral = collateral
-    const collateralSymbol = collateral.symbol.toLowerCase()
-    if (collateralSymbol in CompoundTokenType) {
-      const nativeCompoundAsset = getNativeCompoundAsset(networkId)
-      if (collateralSymbol === nativeCompoundAsset.symbol.toLowerCase()) {
-        baseCollateral = getNativeAsset(networkId)
-      } else {
-        const baseCollateralSymbol = getBaseTokenForCToken(collateral.symbol.toLowerCase()) as KnownToken
-        baseCollateral = getToken(networkId, baseCollateralSymbol)
-      }
-    }
     const { currentDisplayPrice, currentPrice, outcomeName, payout, shares } = balanceItem
     let currentPriceValue = Number(currentPrice)
     if (currentDisplayPrice && Number(currentDisplayPrice) > 0) {
@@ -241,10 +225,10 @@ export const OutcomeTable = (props: Props) => {
     const currentPriceFormatted = withWinningOutcome ? payout.toFixed(2) : currentPriceDisplay
     const probability = withWinningOutcome ? Number(payout.mul(100).toString()) : probabilities[outcomeIndex]
     const newPrice = (probabilities[outcomeIndex] / 100).toFixed(2)
-    const formattedPayout = formatBigNumber(mulBN(shares, Number(payout.toString())), currentCollateral.decimals)
-    const formattedShares = formatBigNumber(shares, baseCollateral.decimals)
+    const formattedPayout = formatBigNumber(mulBN(shares, Number(payout.toString())), collateral.decimals)
+    const formattedShares = formatBigNumber(shares, collateral.decimals)
     const isWinningOutcome = payouts && payouts[outcomeIndex] && payouts[outcomeIndex].gt(0)
-    const formattedNewShares = newShares ? formatBigNumber(newShares[outcomeIndex], baseCollateral.decimals) : null
+    const formattedNewShares = newShares ? formatBigNumber(newShares[outcomeIndex], collateral.decimals) : null
     const showBondBadge = isBond && withWinningOutcome && outcomeIndex === winningBondIndex
     const formattedBondedEth =
       bonds && bonds[outcomeIndex] && bonds[outcomeIndex].bondedEth
@@ -353,13 +337,13 @@ export const OutcomeTable = (props: Props) => {
     )
   }
 
-  const renderTable = () => displayBalances.map((balanceItem: BalanceItem, index) => renderTableRow(balanceItem, index))
+  const renderTable = () => balances.map((balanceItem: BalanceItem, index) => renderTableRow(balanceItem, index))
 
   return (
     <TableWrapper>
       <Table head={renderTableHeader()}>
         {renderTable()}
-        {isBond && renderInvalidRow(displayBalances.length)}
+        {isBond && renderInvalidRow(balances.length)}
       </Table>
     </TableWrapper>
   )

--- a/app/src/components/market/sections/market_buy/market_buy.tsx
+++ b/app/src/components/market/sections/market_buy/market_buy.tsx
@@ -14,11 +14,10 @@ import {
   useContracts,
   useCpkAllowance,
   useCpkProxy,
-  useSymbol,
 } from '../../../../hooks'
 import { MarketMakerService } from '../../../../services'
 import { getLogger } from '../../../../util/logger'
-import { getNativeAsset, getWrapToken, pseudoNativeAssetAddress } from '../../../../util/networks'
+import { getNativeAsset, pseudoNativeAssetAddress } from '../../../../util/networks'
 import { RemoteData } from '../../../../util/remote_data'
 import {
   computeBalanceAfterTrade,
@@ -28,7 +27,6 @@ import {
   mulBN,
 } from '../../../../util/tools'
 import {
-  CompoundTokenType,
   MarketDetailsTab,
   MarketMakerData,
   OutcomeTableValue,
@@ -85,20 +83,10 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
   const { address: marketMakerAddress, balances, fee, question } = marketMakerData
   const marketMaker = useMemo(() => buildMarketMaker(marketMakerAddress), [buildMarketMaker, marketMakerAddress])
 
-  const wrapToken = getWrapToken(networkId)
   const nativeAsset = getNativeAsset(networkId, relay)
-  const initialCollateral =
-    marketMakerData.collateral.address.toLowerCase() === wrapToken.address.toLowerCase()
-      ? nativeAsset
-      : marketMakerData.collateral
-
+  const initialCollateral = getInitialCollateral(networkId, marketMakerData.collateral, relay)
   const [collateral, setCollateral] = useState<Token>(initialCollateral)
-  const collateralSymbol = collateral.symbol.toLowerCase()
 
-  const baseCollateral = getInitialCollateral(networkId, collateral, relay)
-  const [displayCollateral, setDisplayCollateral] = useState<Token>(baseCollateral)
-
-  const symbol = useSymbol(displayCollateral)
   const [status, setStatus] = useState<Status>(Status.Ready)
   const [outcomeIndex, setOutcomeIndex] = useState<number>(0)
   const [amount, setAmount] = useState<Maybe<BigNumber>>(new BigNumber(0))
@@ -109,7 +97,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
   const [newShares, setNewShares] = useState<Maybe<BigNumber[]>>(null)
   const [displayFundAmount, setDisplayFundAmount] = useState<Maybe<BigNumber>>(new BigNumber(0))
   const [allowanceFinished, setAllowanceFinished] = useState(false)
-  const { allowance, unlock } = useCpkAllowance(signer, displayCollateral.address)
+  const { allowance, unlock } = useCpkAllowance(signer, collateral.address)
   const hasEnoughAllowance = RemoteData.mapToTernary(allowance, allowance => allowance.gte(amount || Zero))
   const hasZeroAllowance = RemoteData.mapToTernary(allowance, allowance => allowance.isZero())
 
@@ -165,7 +153,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
   )
 
   const { collateralBalance: maybeCollateralBalance, fetchCollateralBalance } = useCollateralBalance(
-    displayCollateral,
+    collateral,
     context,
   )
   const collateralBalance = maybeCollateralBalance || Zero
@@ -180,10 +168,10 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
   }
 
   const showUpgrade =
-    (!isUpdated && displayCollateral.address === pseudoNativeAssetAddress) ||
-    (upgradeFinished && displayCollateral.address === pseudoNativeAssetAddress)
+    (!isUpdated && collateral.address === pseudoNativeAssetAddress) ||
+    (upgradeFinished && collateral.address === pseudoNativeAssetAddress)
 
-  const shouldDisplayMaxButton = displayCollateral.address !== pseudoNativeAssetAddress
+  const shouldDisplayMaxButton = collateral.address !== pseudoNativeAssetAddress
 
   const upgradeProxy = async () => {
     if (!cpk) {
@@ -200,12 +188,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
         return
       }
 
-      const inputCollateral =
-        collateral.symbol !== displayCollateral.symbol && collateral.symbol === nativeAsset.symbol
-          ? displayCollateral
-          : collateral
-
-      const sharesAmount = formatBigNumber(tradedShares, baseCollateral.decimals, baseCollateral.decimals)
+      const sharesAmount = formatBigNumber(tradedShares, collateral.decimals, collateral.decimals)
       setTweet('')
       setStatus(Status.Loading)
       setMessage(`Buying ${formatNumber(sharesAmount)} shares...`)
@@ -215,7 +198,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
 
       await cpk.buyOutcomes({
         amount: amount || Zero,
-        collateral: inputCollateral,
+        collateral,
         marketMaker,
         outcomeIndex,
         setTxHash,
@@ -247,7 +230,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
   }
 
   const showSetAllowance =
-    displayCollateral.address !== pseudoNativeAssetAddress &&
+    collateral.address !== pseudoNativeAssetAddress &&
     !cpk?.isSafeApp &&
     (allowanceFinished || hasZeroAllowance === Ternary.True || hasEnoughAllowance === Ternary.False)
 
@@ -258,17 +241,17 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
   const potentialProfit = tradedShares.isZero() ? new BigNumber(0) : tradedShares.sub(amount || Zero)
 
   const currentBalance = `${formatBigNumber(collateralBalance, collateral.decimals, 5)}`
-  const feeFormatted = `${formatNumber(
-    formatBigNumber(feePaid.mul(-1), displayCollateral.decimals, displayCollateral.decimals),
-  )} ${displayCollateral.symbol}`
+  const feeFormatted = `${formatNumber(formatBigNumber(feePaid.mul(-1), collateral.decimals, collateral.decimals))} ${
+    collateral.symbol
+  }`
   const baseCostFormatted = `${formatNumber(
-    formatBigNumber(baseCost || Zero, displayCollateral.decimals, displayCollateral.decimals),
+    formatBigNumber(baseCost || Zero, collateral.decimals, collateral.decimals),
   )}
-    ${displayCollateral.symbol}`
+    ${collateral.symbol}`
   const potentialProfitFormatted = `${formatNumber(
-    formatBigNumber(potentialProfit, displayCollateral.decimals, displayCollateral.decimals),
-  )} ${displayCollateral.symbol}`
-  const sharesTotal = formatNumber(formatBigNumber(tradedShares, baseCollateral.decimals, baseCollateral.decimals))
+    formatBigNumber(potentialProfit, collateral.decimals, collateral.decimals),
+  )} ${collateral.symbol}`
+  const sharesTotal = formatNumber(formatBigNumber(tradedShares, collateral.decimals, collateral.decimals))
   const total = `${sharesTotal} Shares`
 
   const amountError = isTransactionProcessing
@@ -278,53 +261,27 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
     : maybeCollateralBalance.isZero() && amount?.gt(maybeCollateralBalance)
     ? `Insufficient balance`
     : amount?.gt(maybeCollateralBalance)
-    ? `Value must be less than or equal to ${currentBalance} ${symbol}`
+    ? `Value must be less than or equal to ${currentBalance} ${collateral.symbol}`
     : null
 
   const isBuyDisabled =
     !amount ||
     (status !== Status.Ready && status !== Status.Error) ||
     amount?.isZero() ||
-    (!cpk?.isSafeApp &&
-      displayCollateral.address !== pseudoNativeAssetAddress &&
-      hasEnoughAllowance !== Ternary.True) ||
+    (!cpk?.isSafeApp && collateral.address !== pseudoNativeAssetAddress && hasEnoughAllowance !== Ternary.True) ||
     amountError !== null ||
     isNegativeAmount ||
-    (!isUpdated && displayCollateral.address === pseudoNativeAssetAddress)
-
-  let currencyFilters =
-    collateral.address === wrapToken.address || collateral.address === pseudoNativeAssetAddress
-      ? [wrapToken.address.toLowerCase(), pseudoNativeAssetAddress.toLowerCase()]
-      : []
-
-  if (collateralSymbol in CompoundTokenType) {
-    if (baseCollateral.symbol.toLowerCase() === 'eth') {
-      currencyFilters = [collateral.address.toLowerCase(), pseudoNativeAssetAddress.toLowerCase()]
-    } else {
-      currencyFilters = [collateral.address.toLowerCase(), baseCollateral.address.toLowerCase()]
-    }
-  }
+    (!isUpdated && collateral.address === pseudoNativeAssetAddress)
 
   const switchOutcome = (value: number) => {
     setNewShares(balances.map((balance, i) => (i === outcomeIndex ? balance.shares.add(tradedShares) : balance.shares)))
     setOutcomeIndex(value)
   }
 
-  const setBuyCollateral = (token: Token) => {
-    if (token.address === pseudoNativeAssetAddress && !(collateral.symbol.toLowerCase() in CompoundTokenType)) {
-      setCollateral(token)
-      setDisplayCollateral(token)
-    } else {
-      setDisplayCollateral(token)
-    }
-  }
-
   const setDisplayAmountToFund = (value: BigNumber) => {
     setAmount(value)
     setDisplayFundAmount(value)
   }
-
-  const currencySelectorIsDisabled = relay ? true : currencyFilters.length ? false : true
 
   return (
     <>
@@ -337,8 +294,6 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
           OutcomeTableValue.Probability,
           OutcomeTableValue.Bonded,
         ]}
-        displayBalances={balances}
-        displayCollateral={baseCollateral}
         newShares={newShares}
         outcomeHandleChange={(value: number) => switchOutcome(value)}
         outcomeSelected={outcomeIndex}
@@ -360,19 +315,10 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
             <CurrencySelector
               addBalances
               addNativeAsset
-              balance={formatBigNumber(maybeCollateralBalance || Zero, displayCollateral.decimals, 5)}
+              balance={formatBigNumber(maybeCollateralBalance || Zero, collateral.decimals, 5)}
               context={context}
-              currency={displayCollateral.address}
-              disabled={currencySelectorIsDisabled}
-              filters={currencyFilters}
-              onSelect={(token: Token | null) => {
-                if (token) {
-                  setBuyCollateral(token)
-                  setAmount(new BigNumber(0))
-                  setAmountToDisplay('')
-                  setDisplayAmountToFund(new BigNumber(0))
-                }
-              }}
+              currency={collateral.address}
+              disabled
             />
           </CurrenciesWrapper>
           <ReactTooltip id="walletBalanceTooltip" />
@@ -380,7 +326,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
           <TextfieldCustomPlaceholder
             formField={
               <BigNumberInput
-                decimals={displayCollateral.decimals}
+                decimals={collateral.decimals}
                 name="amount"
                 onChange={(e: BigNumberInputReturn) => {
                   setDisplayAmountToFund(e.value)
@@ -393,10 +339,10 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
             }
             onClickMaxButton={() => {
               setDisplayAmountToFund(collateralBalance)
-              setAmountToDisplay(formatBigNumber(collateralBalance, displayCollateral.decimals, 5))
+              setAmountToDisplay(formatBigNumber(collateralBalance, collateral.decimals, 5))
             }}
             shouldDisplayMaxButton={shouldDisplayMaxButton}
-            symbol={displayCollateral.symbol}
+            symbol={collateral.symbol}
           />
           {amountError && <GenericError>{amountError}</GenericError>}
         </div>
@@ -436,7 +382,7 @@ const MarketBuyWrapper: React.FC<Props> = (props: Props) => {
       )}
       {showSetAllowance && (
         <SetAllowance
-          collateral={displayCollateral}
+          collateral={collateral}
           finished={allowanceFinished && RemoteData.is.success(allowance)}
           loading={RemoteData.is.asking(allowance)}
           onUnlock={unlockCollateral}

--- a/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
@@ -32,7 +32,6 @@ import {
   formatNumber,
   getBaseTokenForCToken,
   getInitialCollateral,
-  getSharesInBaseToken,
 } from '../../../../util/tools'
 import {
   CompoundTokenType,
@@ -455,10 +454,6 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
     }
   }
 
-  let displayBalances = balances
-  if (compoundService && collateral.symbol.toLowerCase() in CompoundTokenType) {
-    displayBalances = getSharesInBaseToken(balances, compoundService, displayCollateral)
-  }
   const shouldDisplayMaxButton = collateral.address !== pseudoNativeAssetAddress
 
   let displayTotalUserLiquidity = totalUserLiquidity
@@ -582,8 +577,6 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
         balances={balances}
         collateral={collateral}
         disabledColumns={[OutcomeTableValue.OutcomeProbability, OutcomeTableValue.Payout, OutcomeTableValue.Bonded]}
-        displayBalances={displayBalances}
-        displayCollateral={baseCollateral}
         displayRadioSelection={false}
         newShares={activeTab === Tabs.deposit ? displaySharesAfterAddingFunding : displaySharesAfterRemovingFunding}
         probabilities={probabilities}

--- a/app/src/components/market/sections/market_sell/market_sell.tsx
+++ b/app/src/components/market/sections/market_sell/market_sell.tsx
@@ -22,7 +22,6 @@ import {
   formatBigNumber,
   formatNumber,
   getInitialCollateral,
-  getSharesInBaseToken,
   mulBN,
 } from '../../../../util/tools'
 import {
@@ -125,15 +124,6 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
     setAmountSharesToDisplay('')
     // eslint-disable-next-line
   }, [collateral.address])
-
-  let displayBalances = balances
-  if (
-    baseCollateral.address !== collateral.address &&
-    collateral.symbol.toLowerCase() in CompoundTokenType &&
-    compoundService
-  ) {
-    displayBalances = getSharesInBaseToken(balances, compoundService, displayCollateral)
-  }
 
   const calcSellAmount = useMemo(
     () => async (
@@ -358,8 +348,6 @@ const MarketSellWrapper: React.FC<Props> = (props: Props) => {
           OutcomeTableValue.Probability,
           OutcomeTableValue.Bonded,
         ]}
-        displayBalances={displayBalances}
-        displayCollateral={displayCollateral}
         newShares={displayNewShares}
         outcomeHandleChange={(value: number) => {
           setOutcomeIndex(value)

--- a/app/src/util/tools.spec.ts
+++ b/app/src/util/tools.spec.ts
@@ -2,7 +2,7 @@
 import Big from 'big.js'
 import { BigNumber, bigNumberify, parseUnits } from 'ethers/utils'
 
-import { getContractAddress, getNativeAsset, getToken } from './networks'
+import { getContractAddress, getNativeAsset } from './networks'
 import {
   bigMax,
   bigMin,
@@ -687,7 +687,6 @@ describe('tools', () => {
     const testCases: [[number, Token], Token][] = [
       [[1, getNativeAsset(1)], getNativeAsset(1)],
       [[4, getNativeAsset(4)], getNativeAsset(4)],
-      [[4, getToken(4, 'ceth' as KnownToken)], getNativeAsset(4)],
       [[77, getNativeAsset(77)], getNativeAsset(77)],
       [[100, getNativeAsset(100)], getNativeAsset(100)],
     ]

--- a/app/src/util/tools.ts
+++ b/app/src/util/tools.ts
@@ -753,21 +753,10 @@ export const bigMin = (array: Big[]) => {
  * Else display is the collateral
  */
 export const getInitialCollateral = (networkId: number, collateral: Token, relay = false): Token => {
-  const collateralSymbol = collateral.symbol.toLowerCase()
-  if (collateralSymbol in CompoundTokenType) {
-    if (collateralSymbol === 'ceth') {
-      return getNativeAsset(networkId)
-    } else {
-      const baseCollateralSymbol = getBaseTokenForCToken(collateralSymbol) as KnownToken
-      const baseToken = getToken(networkId, baseCollateralSymbol)
-      return baseToken
-    }
+  if (collateral.address === getWrapToken(networkId).address) {
+    return getNativeAsset(networkId, relay)
   } else {
-    if (collateral.address === getWrapToken(networkId).address) {
-      return getNativeAsset(networkId, relay)
-    } else {
-      return collateral
-    }
+    return collateral
   }
 }
 

--- a/app/src/util/tools.ts
+++ b/app/src/util/tools.ts
@@ -749,8 +749,6 @@ export const bigMin = (array: Big[]) => {
 
 /**
  *  Gets initial display collateral
- * If collateral is cToken type then display is the base collateral
- * Else display is the collateral
  */
 export const getInitialCollateral = (networkId: number, collateral: Token, relay = false): Token => {
   if (collateral.address === getWrapToken(networkId).address) {


### PR DESCRIPTION
related https://github.com/protofire/omen-exchange/issues/2012 

Will split this refactor into a few different PRs to make review easier. This PR removes compound logic from both categorical and scalar market buys.

Additional change - In the spirit of simplifying the code and user experience, the option to buy using wrapped assets on native asset markets has been removed, e.g. you can only buy with the native asset (ETH) you cannot buy with the wrapped asset (WETH).

Testing:
- [ ] DAI categorical market buy - works, UI looks normal
- [ ] DAI scalar market buy - works, UI looks normal
- [ ] ETH categorical market buy - works, UI looks normal
- [ ] ETH scalar market buy - works, UI looks normal



