### PR TITLE
Properly track liquidity

### DIFF
--- a/app/src/components/market/common/list_item/index.tsx
+++ b/app/src/components/market/common/list_item/index.tsx
@@ -105,7 +105,6 @@ export const ListItem: React.FC<Props> = (props: Props) => {
     runningDailyVolumeByHour,
     scalarHigh,
     scalarLow,
-    scaledLiquidityParameter,
     title,
   } = market
 

--- a/app/src/components/market/common/market_top_details_closed/index.tsx
+++ b/app/src/components/market/common/market_top_details_closed/index.tsx
@@ -1,15 +1,16 @@
 import { BigNumber } from 'ethers/utils'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useHistory } from 'react-router'
 import styled from 'styled-components'
 
-import { useConnectedWeb3Context } from '../../../../hooks'
+import { STANDARD_DECIMALS } from '../../../../common/constants'
+import { useConnectedWeb3Context, useContracts } from '../../../../hooks'
 import { useGraphMarketsFromQuestion } from '../../../../hooks/useGraphMarketsFromQuestion'
 import { useWindowDimensions } from '../../../../hooks/useWindowDimensions'
 import { CompoundService } from '../../../../services'
 import theme from '../../../../theme'
 import { getContractAddress, getNativeAsset, getWrapToken } from '../../../../util/networks'
-import { getMarketRelatedQuestionFilter, onChangeMarketCurrency } from '../../../../util/tools'
+import { formatBigNumber, getMarketRelatedQuestionFilter, onChangeMarketCurrency } from '../../../../util/tools'
 import { MarketMakerData, MarketState, Token } from '../../../../util/types'
 import { SubsectionTitleWrapper } from '../../../common'
 import { AdditionalMarketData } from '../additional_market_data'
@@ -61,17 +62,28 @@ const MarketTopDetailsClosed: React.FC<Props> = (props: Props) => {
     lastActiveDay,
     question,
     runningDailyVolumeByHour,
-    scaledLiquidityParameter,
     submissionIDs,
   } = marketMakerData
   const { title } = question
   const ovmAddress = getContractAddress(networkId, 'omenVerifiedMarkets')
 
   const [showingProgressBar, setShowingProgressBar] = useState(false)
+  const [liquidity, setLiquidity] = useState(new BigNumber(0))
 
   const creationDate = new Date(1000 * parseInt(creationTimestamp))
 
-  const formattedLiquidity: string = scaledLiquidityParameter ? scaledLiquidityParameter.toFixed(2) : '0'
+  const contracts = useContracts(context)
+  const { buildMarketMaker } = contracts
+  const marketMaker = buildMarketMaker(address)
+
+  useEffect(() => {
+    const getLiquidity = async () => {
+      setLiquidity(await marketMaker.getTotalSupply())
+    }
+    marketMaker && getLiquidity()
+  })
+
+  const formattedLiquidity: string = formatBigNumber(liquidity, STANDARD_DECIMALS, 2)
 
   const isPendingArbitration = question.isPendingArbitration
   const arbitrationOccurred = question.arbitrationOccurred

--- a/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
@@ -244,9 +244,11 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
     totalPoolShares,
   )
 
-  const totalDepositedTokens = totalUserShareAmounts.reduce((min: BigNumber, amount: BigNumber) =>
-    amount.lt(min) ? amount : min,
-  )
+  const totalDepositedTokens = totalUserShareAmounts
+    .map((amount, i) => {
+      return amount.add(balances[i].shares)
+    })
+    .reduce((min: BigNumber, amount: BigNumber) => (amount.lt(min) ? amount : min))
 
   const totalUserLiquidity = totalDepositedTokens.add(userEarnings)
 

--- a/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
@@ -244,11 +244,13 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
     totalPoolShares,
   )
 
-  const totalDepositedTokens = totalUserShareAmounts
-    .map((amount, i) => {
-      return amount.add(balances[i].shares)
-    })
-    .reduce((min: BigNumber, amount: BigNumber) => (amount.lt(min) ? amount : min))
+  const totalDepositedTokens = fundingBalance.gt(0)
+    ? totalUserShareAmounts
+        .map((amount, i) => {
+          return amount.add(balances[i].shares)
+        })
+        .reduce((min: BigNumber, amount: BigNumber) => (amount.lt(min) ? amount : min))
+    : new BigNumber(0)
 
   const totalUserLiquidity = totalDepositedTokens.add(userEarnings)
 

--- a/app/src/components/market/sections/market_pooling/scalar_market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/scalar_market_pool_liquidity.tsx
@@ -229,8 +229,12 @@ export const ScalarMarketPoolLiquidity = (props: Props) => {
     totalPoolShares,
   )
 
-  const totalDepositedTokens = totalUserShareAmounts.length
-    ? totalUserShareAmounts.reduce((min: BigNumber, amount: BigNumber) => (amount.lt(min) ? amount : min))
+  const totalDepositedTokens = fundingBalance.gt(0)
+    ? totalUserShareAmounts
+        .map((amount, i) => {
+          return amount.add(balances[i].shares)
+        })
+        .reduce((min: BigNumber, amount: BigNumber) => (amount.lt(min) ? amount : min))
     : new BigNumber(0)
 
   const totalUserLiquidity = totalDepositedTokens.add(userEarnings)


### PR DESCRIPTION
Closes: https://github.com/protofire/omen-exchange/issues/2066

Testing: 
Can test by going to etherscan for market and checking `totalSupply`
- [ ] List item view
- [ ] Market details
    - [ ] Open market
    - [ ] Closed market
- [ ] Scalar market pool view
    - [ ] Your liquidity
        - Should be equal to the amount you receive for withdrawing max
- [ ] Categorical market pool view
    - [ ] Your liquidity
        - Should be equal to the amount you receive for withdrawing max
- [ ] Anywhere else?