### PR TITLE
Handle xdai bond fee

### DIFF
--- a/app/src/services/realitio.ts
+++ b/app/src/services/realitio.ts
@@ -9,7 +9,7 @@ import { Moment } from 'moment'
 import { REALITIO_TIMEOUT, SINGLE_SELECT_TEMPLATE_ID, UINT_TEMPLATE_ID } from '../common/constants'
 import { Outcome } from '../components/market/sections/market_create/steps/outcomes'
 import { getLogger } from '../util/logger'
-import { getEarliestBlockToCheck, getRealitioTimeout } from '../util/networks'
+import { getEarliestBlockToCheck, getRealitioTimeout, networkIds } from '../util/networks'
 import { Question, QuestionLog, TransactionStep } from '../util/types'
 
 const logger = getLogger('Services::Realitio')
@@ -209,6 +209,11 @@ class RealitioService {
     // Calc claimable bonds by matching claimWinnings internals: https://github.com/realitio/realitio-contracts/blob/master/truffle/contracts/Realitio.sol#L506
     const events = await this.getAnswers(questionId)
 
+    // 2.5% bond fee for xdai
+    const BOND_CLAIM_FEE_PROPORTION = new BigNumber('40')
+    const network = await this.provider.getNetwork()
+    const networkId = network.chainId
+
     let payee = AddressZero
     let queuedFunds = new BigNumber('0')
     let lastBond = new BigNumber('0')
@@ -237,6 +242,11 @@ class RealitioService {
       }
 
       lastBond = values.bond
+
+      // handle bond fee on xdai - only the last bond is exempt from the bond fee
+      if (networkId === networkIds.XDAI && !lastBond.eq(question.bond)) {
+        lastBond = lastBond.sub(lastBond.div(BOND_CLAIM_FEE_PROPORTION))
+      }
     }
 
     // There is nothing left below this bond so the payee can keep what remains


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/2050

The realitio contract on xdai is slightly different to other networks, to prevent griefing it takes a 2.5% fee of every bond except the last bond.

PR takes the bond fee into account when calculating claimable bond balances.

Testing:

Just a recap - It is easier to test on xdai if you set [timeIntervals](https://github.com/protofire/omen-exchange/blob/3e0a5c17a86854ec99dae45ea5f2d1edadfe5bd9/app/src/components/common/form/date_field/index.tsx#L137) to 5 and [realitioTimeout](https://github.com/protofire/omen-exchange/blob/master/app/src/util/networks.ts#L254) to 180.

The scenario below is what happened in the linked issue:

- [ ] Create a market on xdai
- [ ] Account A buys winning outcome
- [ ] Account A bonds winning outcome
- [ ] Account B bonds winning outcome
- [ ] Account A is able to resolve + redeem position + redeem bond
- [ ] Account B is able to redeem bond