### PR TITLE
Disable withdraw tab when user has no liquidity

### DIFF
--- a/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/market_pool_liquidity.tsx
@@ -33,6 +33,7 @@ import {
   getBaseTokenForCToken,
   getInitialCollateral,
   getSharesInBaseToken,
+  isDust,
 } from '../../../../util/tools'
 import {
   CompoundTokenType,
@@ -570,6 +571,8 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
 
   const currencySelectorIsDisabled = relay ? true : currencyFilters.length ? false : true
 
+  const disableWithdrawTab = activeTab !== Tabs.withdraw && isDust(totalUserLiquidity, collateral.decimals)
+
   return (
     <>
       <UserPoolData
@@ -603,6 +606,7 @@ const MarketPoolLiquidityWrapper: React.FC<Props> = (props: Props) => {
             </ButtonTab>
             <ButtonTab
               active={disableDepositTab ? true : activeTab === Tabs.withdraw}
+              disabled={disableWithdrawTab}
               onClick={() => switchTab(Tabs.withdraw)}
             >
               Withdraw

--- a/app/src/components/market/sections/market_pooling/scalar_market_pool_liquidity.tsx
+++ b/app/src/components/market/sections/market_pooling/scalar_market_pool_liquidity.tsx
@@ -203,7 +203,6 @@ export const ScalarMarketPoolLiquidity = (props: Props) => {
     balances.map(b => b.holdings),
     totalPoolShares,
   )
-  const disableWithdrawTab = isDust(fundingBalance, collateral.decimals)
 
   const sendAmountsAfterRemovingFunding = calcRemoveFundingSendAmounts(
     amountToRemove || Zero,
@@ -560,6 +559,8 @@ export const ScalarMarketPoolLiquidity = (props: Props) => {
     sharesAmountError !== null ||
     isNegativeAmountToRemove
 
+  const disableWithdrawTab = activeTab !== Tabs.withdraw && isDust(totalUserLiquidity, collateral.decimals)
+
   return (
     <>
       <UserPoolData
@@ -593,7 +594,7 @@ export const ScalarMarketPoolLiquidity = (props: Props) => {
               Deposit
             </ButtonTab>
             <ButtonTab
-              active={!disableWithdrawTab && activeTab === Tabs.withdraw}
+              active={activeTab === Tabs.withdraw}
               disabled={disableWithdrawTab}
               onClick={() => setActiveTab(Tabs.withdraw)}
             >


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/2065

Testing for both categorical and scalar:

- [ ] If the user has no liquidity when the Deposit tab is selected the Withdraw tab is disabled 
- [ ] If the user has liquidity, the Withdraw tab is selected, and the user withdraws all liquidity, the Withdraw tab is still enabled but switching back to the Deposit tab disables it