### PR TITLE
Feature/2070-Rephrase Text Allowance

### DIFF
--- a/app/src/components/market/common/set_allowance/index.tsx
+++ b/app/src/components/market/common/set_allowance/index.tsx
@@ -45,13 +45,13 @@ export const SetAllowance: React.FC<SetAllowanceProps> = (props: SetAllowancePro
 
   return (
     <Wrapper {...restProps}>
-      <Title>{collateral ? 'Set Allowance' : 'Enable Markets'}</Title>
+      <Title>{collateral ? 'Set Allowance' : 'Upgrade Omen Account'}</Title>
       <DescriptionWrapper>
         <Description>
           {collateral
             ? `This permission allows the smart contracts to interact with your ${collateral &&
                 collateral.symbol}. This has to be done for each new token.`
-            : `This permission allows you to interact with market contracts.`}
+            : `A new version of the Omen account smart contract is available. Upgrade your Omen account now.`}
         </Description>
         <ToggleTokenLock finished={finished} loading={loading} onUnlock={onUnlock} />
       </DescriptionWrapper>

--- a/app/src/components/market/common/toggle_token_lock/index.tsx
+++ b/app/src/components/market/common/toggle_token_lock/index.tsx
@@ -15,7 +15,7 @@ export const ToggleTokenLock = (props: ToggleTokenLockProps) => {
 
   return (
     <ButtonStateful disabled={loading || finished} onClick={onUnlock} state={state}>
-      Set
+      Upgrade
     </ButtonStateful>
   )
 }


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/2070

Fix: Fixed text on the CPK upgrade card