### PR TITLE
Make Omen work with new TheGraph gateway

### DIFF
--- a/app/src/common/constants.ts
+++ b/app/src/common/constants.ts
@@ -53,7 +53,11 @@ export const TRADING_FEE_OPTIONS = [
   '5.00',
 ]
 
-export const GRAPH_MAINNET_HTTP = 'https://api.thegraph.com/subgraphs/name/protofire/omen'
+export const GRAPH_MAINNET_HTTP =
+  'https://gateway.thegraph.com/api/' +
+  process.env.REACT_APP_GRAPH_API_KEY +
+  '/subgraphs/id/' +
+  process.env.REACT_APP_GRAPH_SUBGRAPH_ID
 export const GRAPH_MAINNET_WS = 'wss://api.thegraph.com/subgraphs/name/protofire/omen'
 export const GRAPH_RINKEBY_HTTP = 'https://api.thegraph.com/subgraphs/name/protofire/omen-rinkeby'
 export const GRAPH_RINKEBY_WS = 'wss://api.thegraph.com/subgraphs/name/protofire/omen-rinkeby'


### PR DESCRIPTION
In the view of the migration to the new The Graph Mainnet network (https://thegraph.com/blog/mainnet-migration), it's now required to make HTTP requests to TheGraph go through the new gateway system.

To achieve it, it's necessary to set an API Key and the Subgraph ID as environment variables.

Omen subgraph, initially owned by Gnosis, was one of the subgraphs designated for the first migration phase (https://thegraph.com/blog/mainnet-migration-partners).

