### PR TITLE
Prevent crashes on connection changes when viewing market list

### DIFF
--- a/app/src/components/market/common/list_item/index.tsx
+++ b/app/src/components/market/common/list_item/index.tsx
@@ -139,7 +139,8 @@ export const ListItem: React.FC<Props> = (props: Props) => {
       setLiquidity(await marketMaker.getTotalSupply())
     }
     marketMaker && getLiquidity()
-  })
+    // eslint-disable-next-line
+  }, [])
 
   const formattedLiquidity: string = formatBigNumber(liquidity, STANDARD_DECIMALS, 2)
 

--- a/app/src/components/market/common/market_top_details_closed/index.tsx
+++ b/app/src/components/market/common/market_top_details_closed/index.tsx
@@ -81,7 +81,8 @@ const MarketTopDetailsClosed: React.FC<Props> = (props: Props) => {
       setLiquidity(await marketMaker.getTotalSupply())
     }
     marketMaker && getLiquidity()
-  })
+    // eslint-disable-next-line
+  }, [])
 
   const formattedLiquidity: string = formatBigNumber(liquidity, STANDARD_DECIMALS, 2)
 

--- a/app/src/components/market/common/market_top_details_open/index.tsx
+++ b/app/src/components/market/common/market_top_details_open/index.tsx
@@ -83,7 +83,8 @@ const MarketTopDetailsOpen: React.FC<Props> = (props: Props) => {
       setLiquidity(await marketMaker.getTotalSupply())
     }
     marketMaker && getLiquidity()
-  })
+    // eslint-disable-next-line
+  }, [])
 
   const formattedLiquidity: string = formatBigNumber(liquidity, STANDARD_DECIMALS, 2)
 

--- a/app/src/components/market/sections/market_list/market_home_container.tsx
+++ b/app/src/components/market/sections/market_list/market_home_container.tsx
@@ -270,13 +270,12 @@ const MarketHomeContainer: React.FC = () => {
     } else if (fetchedMarkets) {
       const { fixedProductMarketMakers } = fetchedMarkets
       setMarkets(RemoteData.success(wrangleResponse(fixedProductMarketMakers, context.networkId)))
-
       setIsFiltering(false)
     } else if (error) {
       setMarkets(RemoteData.failure(error))
       setIsFiltering(false)
     }
-  }, [fetchedMarkets, loading, error, context.networkId, PAGE_SIZE, pageIndex])
+  }, [fetchedMarkets, loading, error, context.networkId, PAGE_SIZE, pageIndex, cpkAddress])
 
   useEffect(() => {
     if (categoriesLoading) {

--- a/app/src/hooks/connectedWeb3.tsx
+++ b/app/src/hooks/connectedWeb3.tsx
@@ -156,7 +156,14 @@ export const ConnectedWeb3: React.FC<Props> = (props: Props) => {
     }
   }, [context, library, active, error, networkId, safeAppInfo, rpcAddress, debugAddress, debugNetworkId])
 
-  if (!networkId || !library || !connection || (connection.account && !cpk) || !balances.fetched) {
+  if (
+    !networkId ||
+    !library ||
+    !connection ||
+    (connection.account && !cpk) ||
+    (connection.account && connection.networkId !== cpk?.provider?.network?.chainId) ||
+    !balances.fetched
+  ) {
     props.setStatus(true)
     return null
   }

--- a/app/src/hooks/useMarkets.tsx
+++ b/app/src/hooks/useMarkets.tsx
@@ -48,7 +48,6 @@ export const useMarkets = (options: Options): any => {
   } = options
 
   const [moreMarkets, setMoreMarkets] = React.useState(true)
-
   const [markets, setMarkets] = React.useState<GraphResponseMarketsGeneric>({ fixedProductMarketMakers: [] })
 
   const fetchMyMarkets = state === MarketStates.myMarkets
@@ -107,10 +106,13 @@ export const useMarkets = (options: Options): any => {
   })
 
   React.useEffect(() => {
+    if (!loading) {
+      return
+    }
     setMarkets({
       fixedProductMarketMakers: [],
     })
-  }, [arbitrator, currency, curationSource, category, state, sortBy, templateId])
+  }, [arbitrator, currency, curationSource, category, state, sortBy, templateId, loading])
 
   return { markets, error, fetchMore, loading, moreMarkets }
 }


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/2088
closes https://github.com/protofire/omen-exchange/issues/2083

Main issue was stale market data during loading of a new market list, the old market list would be rendered briefly while using the old connection causing the 'contract not deployed' errors. Updated to clear the market list on reload.

Added a check to make sure the app is only rendered if the connection networkId and the CPK networkId are in sync so that we can prevent fetching data we don't want.

Something I missed in code review and I only just learned about: useEffect without a dependency array will run on every render, we had a few of these which led to some infinite loops, removed now.