### PR TITLE
Filter markets by known oracles

### DIFF
--- a/app/src/components/market/sections/market_list/market_home_container.tsx
+++ b/app/src/components/market/sections/market_list/market_home_container.tsx
@@ -13,7 +13,7 @@ import { useConnectedWeb3Context } from '../../../../hooks'
 import { useMarkets } from '../../../../hooks/useMarkets'
 import { queryCategories } from '../../../../queries/markets_home'
 import theme from '../../../../theme'
-import { getArbitratorsByNetwork, getOutcomes, networkIds } from '../../../../util/networks'
+import { getArbitratorsByNetwork, getContractAddress, getOutcomes, networkIds } from '../../../../util/networks'
 import { RemoteData } from '../../../../util/remote_data'
 import {
   CategoryDataItem,
@@ -241,6 +241,9 @@ const MarketHomeContainer: React.FC = () => {
   const feeBN = ethers.utils.parseEther('' + MAX_MARKET_FEE / Math.pow(10, 2))
 
   const knownArbitrators = getArbitratorsByNetwork(context.networkId).map(x => x.address)
+  const realitioScalarAdapterAddress = getContractAddress(context.networkId, 'realitioScalarAdapter')
+  const oracleAddress = getContractAddress(context.networkId, 'oracle')
+  const knownOracles = [oracleAddress, realitioScalarAdapterAddress]
   const fetchMyMarkets = filter.state === MarketStates.myMarkets
 
   const marketsQueryVariables = {
@@ -251,6 +254,7 @@ const MarketHomeContainer: React.FC = () => {
     fee: feeBN.toString(),
     now: +now,
     knownArbitrators,
+    knownOracles,
     ...filter,
   }
 

--- a/app/src/hooks/useMarkets.tsx
+++ b/app/src/hooks/useMarkets.tsx
@@ -22,6 +22,7 @@ interface MarketVariables {
   fee: string
   now: number
   knownArbitrators: string[]
+  knownOracles: string[]
 }
 
 type Options = MarketVariables & MarketFilters

--- a/app/src/queries/markets_home.spec.ts
+++ b/app/src/queries/markets_home.spec.ts
@@ -7,7 +7,7 @@ import { DEFAULT_OPTIONS, MarketDataFragment, buildQueryMarkets } from './market
 
 const getExpectedQuery = (whereClause: string) => {
   return gql`
-    query GetMarkets($first: Int!, $skip: Int!, $sortBy: String, $sortByDirection: String, $category: String, $title: String, $currency: String, $arbitrator: String, $knownArbitrators: [String!], $templateId: String, $accounts: [String!], $now: Int, $fee: String) {
+    query GetMarkets($first: Int!, $skip: Int!, $sortBy: String, $sortByDirection: String, $category: String, $title: String, $currency: String, $arbitrator: String, $knownArbitrators: [String!], $knownOracles: [String!], $templateId: String, $accounts: [String!], $now: Int, $fee: String) {
       fixedProductMarketMakers(first: $first, skip: $skip, orderBy: $sortBy, orderDirection: $sortByDirection, where: { ${whereClause} }) {
         ...marketData
       }
@@ -19,7 +19,7 @@ const getExpectedQuery = (whereClause: string) => {
 test('Query markets with default options', () => {
   const query = buildQueryMarkets(DEFAULT_OPTIONS)
   const expectedQuery = getExpectedQuery(
-    'openingTimestamp_gt: $now, arbitrator_in: $knownArbitrators, templateId_in: ["0", "1", "2", "6"], fee_lte: $fee, timeout_gte: 86400, curatedByDxDaoOrKleros: true',
+    'openingTimestamp_gt: $now, arbitrator_in: $knownArbitrators, oracle_in: $knownOracles, templateId_in: ["0", "1", "2", "6"], fee_lte: $fee, timeout_gte: 86400, curatedByDxDaoOrKleros: true',
   )
   expect(query).toBe(expectedQuery)
 })
@@ -31,7 +31,7 @@ test('Query markets', () => {
     category: 'SimpleQuestions',
   })
   const expectedQuery = getExpectedQuery(
-    'category: $category, arbitrator_in: $knownArbitrators, templateId_in: ["0", "1", "2", "6"], fee_lte: $fee, timeout_gte: 86400, curatedByDxDaoOrKleros: true',
+    'category: $category, arbitrator_in: $knownArbitrators, oracle_in: $knownOracles, templateId_in: ["0", "1", "2", "6"], fee_lte: $fee, timeout_gte: 86400, curatedByDxDaoOrKleros: true',
   )
   expect(query).toBe(expectedQuery)
 })
@@ -43,7 +43,7 @@ test('Markets with template_id', () => {
     templateId: '2',
   })
   const expectedQuery = getExpectedQuery(
-    'arbitrator_in: $knownArbitrators, templateId: $templateId, fee_lte: $fee, timeout_gte: 86400, curatedByDxDaoOrKleros: true',
+    'arbitrator_in: $knownArbitrators, oracle_in: $knownOracles, templateId: $templateId, fee_lte: $fee, timeout_gte: 86400, curatedByDxDaoOrKleros: true',
   )
   expect(query).toBe(expectedQuery)
 })
@@ -59,7 +59,7 @@ test('Markets closed with title and arbitrator', () => {
     arbitrator: 'arbitratorTest',
   })
   const expectedQuery = getExpectedQuery(
-    'answerFinalizedTimestamp_lt: $now, title_contains: $title, arbitrator: $arbitrator, templateId: $templateId, fee_lte: $fee, timeout_gte: 86400, curatedByDxDaoOrKleros: true',
+    'answerFinalizedTimestamp_lt: $now, title_contains: $title, arbitrator: $arbitrator, oracle_in: $knownOracles, templateId: $templateId, fee_lte: $fee, timeout_gte: 86400, curatedByDxDaoOrKleros: true',
   )
   expect(query).toBe(expectedQuery)
 })
@@ -71,7 +71,7 @@ test('Query finalizing markets', () => {
     category: 'SimpleQuestions',
   })
   const expectedQuery = getExpectedQuery(
-    'openingTimestamp_lt: $now, isPendingArbitration: false, answerFinalizedTimestamp_gt: $now, currentAnswer_not: null, category: $category, arbitrator_in: $knownArbitrators, templateId_in: ["0", "1", "2", "6"], fee_lte: $fee, timeout_gte: 86400, curatedByDxDaoOrKleros: true',
+    'openingTimestamp_lt: $now, isPendingArbitration: false, answerFinalizedTimestamp_gt: $now, currentAnswer_not: null, category: $category, arbitrator_in: $knownArbitrators, oracle_in: $knownOracles, templateId_in: ["0", "1", "2", "6"], fee_lte: $fee, timeout_gte: 86400, curatedByDxDaoOrKleros: true',
   )
 
   expect(query).toBe(expectedQuery)

--- a/app/src/queries/markets_home.ts
+++ b/app/src/queries/markets_home.ts
@@ -56,6 +56,7 @@ export const buildQueryMyMarkets = (options: BuildQueryType = DEFAULT_OPTIONS) =
     sortBy === 'openingTimestamp' ? 'openingTimestamp_gt: $now' : '',
     category === 'All' ? '' : 'category: $category',
     arbitrator ? 'arbitrator: $arbitrator' : 'arbitrator_in: $knownArbitrators',
+    'oracle_in: $knownOracles',
     currency ? 'collateralToken: $currency' : '',
     title ? 'title_contains: $title' : '',
   ]
@@ -107,6 +108,7 @@ export const buildQueryMarkets = (options: BuildQueryType = DEFAULT_OPTIONS) => 
     title ? 'title_contains: $title' : '',
     currency ? 'collateralToken: $currency' : '',
     arbitrator ? 'arbitrator: $arbitrator' : 'arbitrator_in: $knownArbitrators',
+    'oracle_in: $knownOracles',
     templateId ? 'templateId: $templateId' : whitelistedTemplateIds ? 'templateId_in: ["0", "1", "2", "6"]' : '',
     'fee_lte: $fee',
     `timeout_gte: ${MIN_TIMEOUT}`,
@@ -124,7 +126,7 @@ export const buildQueryMarkets = (options: BuildQueryType = DEFAULT_OPTIONS) => 
     .join(',')
 
   const query = gql`
-    query GetMarkets($first: Int!, $skip: Int!, $sortBy: String, $sortByDirection: String, $category: String, $title: String, $currency: String, $arbitrator: String, $knownArbitrators: [String!], $templateId: String, $accounts: [String!], $now: Int, $fee: String) {
+    query GetMarkets($first: Int!, $skip: Int!, $sortBy: String, $sortByDirection: String, $category: String, $title: String, $currency: String, $arbitrator: String, $knownArbitrators: [String!], $knownOracles: [String!], $templateId: String, $accounts: [String!], $now: Int, $fee: String) {
       fixedProductMarketMakers(first: $first, skip: $skip, orderBy: $sortBy, orderDirection: $sortByDirection, where: { ${whereClause} }) {
         ...marketData
       }


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/2099 

Adds a $knownOracles query for the market list, should work when we update the subgraph