### PR TITLE
Use multicall for market data

### DIFF
--- a/app/src/util/multicall.ts
+++ b/app/src/util/multicall.ts
@@ -1,0 +1,21 @@
+import { aggregate } from '@makerdao/multicall'
+import configs from '@makerdao/multicall/src/addresses.json'
+
+import { getInfuraUrl, networkNames } from './networks'
+
+export const getCallSig = (contract: any, fn: string) =>
+  `${contract.contract.interface.functions[fn].signature}(${contract.contract.interface.functions[fn].outputs.map(
+    (output: any) => output.type,
+  )})`
+
+export const getMultiCallConfig = (networkId: number) => {
+  const network = (networkNames as any)[networkId]
+  return {
+    rpcUrl: getInfuraUrl(networkId),
+    multicallAddress: (configs as any)[network.toLowerCase()].multicall,
+  }
+}
+
+export const multicall = async (calls: any, networkId: number) => {
+  return aggregate(calls, getMultiCallConfig(networkId))
+}

--- a/app/src/util/types.ts
+++ b/app/src/util/types.ts
@@ -294,8 +294,6 @@ export interface MarketMakerData {
   isConditionResolved: boolean
   isQuestionFinalized: boolean
   collateralVolume: BigNumber
-  marketMakerFunding: BigNumber
-  marketMakerUserFunding: BigNumber
   payouts: Maybe<Big[]>
   question: Question
   realitioAnswer: Maybe<BigNumber>


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/2010

market loading speed test with basic internet connection:
before: ~5 seconds
after: ~1 second

edit: was able to add one more optimisation based on [conditional token utils](https://github.com/gnosis/conditional-tokens-contracts/blob/master/utils/id-helpers.js#L24) but couldn't get off-chain calculation of collectionIds to work 🤷‍♂️ still got an extra ~1 second improvement doing off-chain positionId calc so that's decent anyway 

testing: market data looks normal 