### PR TITLE
Fix/2148 - Tooltip LP fee shows dynamic value

### DIFF
--- a/app/src/components/market/common_sections/user_transactions_tokens/transaction_details_row/index.tsx
+++ b/app/src/components/market/common_sections/user_transactions_tokens/transaction_details_row/index.tsx
@@ -64,7 +64,7 @@ export const TransactionDetailsRow: React.FC<Props> = props => {
         {title}
         {tooltip ? (
           <>
-            <Circle data-arrow-color="transparent" data-for="fee" data-tip="A 2% fee goes to liquidity providers.">
+            <Circle data-arrow-color="transparent" data-for="fee" data-tip={tooltip}>
               <IconInfo />
             </Circle>
           </>


### PR DESCRIPTION
closes https://github.com/protofire/omen-exchange/issues/2148

Tooltip LP fee shows dynamic value instead of static 3%
