### PR TITLE
Added strict for max button formatting

### DIFF
--- a/app/src/components/modal/modal_lock_yo_tokens/index.tsx
+++ b/app/src/components/modal/modal_lock_yo_tokens/index.tsx
@@ -330,7 +330,7 @@ const ModalLockTokens = (props: Props) => {
                 }
                 onClickMaxButton={() => {
                   setDisplayLockAmount(omenBalance)
-                  setAmountToDisplay(bigNumberToString(omenBalance, STANDARD_DECIMALS, 2))
+                  setAmountToDisplay(bigNumberToString(omenBalance, STANDARD_DECIMALS, 2, true))
                 }}
                 shouldDisplayMaxButton={true}
                 symbol={'OMN'}


### PR DESCRIPTION
- This fixed error that was caused by numbers bigger then 1000 having comma and not being displayed properly on max button click on lock token modal 
- How to test 
https://user-images.githubusercontent.com/33226956/129030595-237fb068-a562-492d-a298-2364888d1cab.mov
- [ ] Make sure above is not happening and it displays appropriate value