### PR TITLE
Only fetch airdrop info when connected to relay

### DIFF
--- a/app/src/components/modal/modal_lock_yo_tokens/index.tsx
+++ b/app/src/components/modal/modal_lock_yo_tokens/index.tsx
@@ -421,7 +421,7 @@ const ModalLockTokens = (props: Props) => {
             </ButtonsLockUnlock>
           </ButtonSection>
         </ContentWrapper>
-        {!isLockAmountOpen && (
+        {!isLockAmountOpen && relay && (
           <>
             <Divider />
             <AirdropCardWrapper

--- a/app/src/hooks/useAirdropService.tsx
+++ b/app/src/hooks/useAirdropService.tsx
@@ -15,7 +15,7 @@ interface AirdropServiceParams {
 }
 
 export const useAirdropService = (): AirdropServiceParams => {
-  const { account, library: provider, networkId } = useConnectedWeb3Context()
+  const { account, library: provider, networkId, relay } = useConnectedWeb3Context()
 
   const [airdrop, setAirdrop] = useState<AirdropService>(new AirdropService(networkId, provider, account))
   const [claimAmount, setClaimAmount] = useState(new BigNumber('0'))
@@ -29,7 +29,7 @@ export const useAirdropService = (): AirdropServiceParams => {
 
   useEffect(() => {
     const status = { active: true }
-    if (account) {
+    if (account && relay) {
       fetchClaimAmount(status)
     }
     return () => {
@@ -39,11 +39,11 @@ export const useAirdropService = (): AirdropServiceParams => {
   }, [airdrop, account, networkId])
 
   useEffect(() => {
-    if (account) {
+    if (account && relay) {
       setAirdrop(new AirdropService(networkId, provider, account))
     }
     // eslint-disable-next-line
-  }, [networkId, account])
+  }, [networkId, account, relay])
 
   return { airdrop, claimAmount, fetchClaimAmount }
 }


### PR DESCRIPTION
Now that we are only doing the airdrop through the relay there is no point fetching airdrop info on other networks.

PR also hides the airdrop card in the guild modal if not connected to the relay.