### PR TITLE
Fix: Fixed collateral description in outcome table when on Set Outcome

### DIFF
--- a/app/src/components/market/common_sections/tables/outcome_table/index.tsx
+++ b/app/src/components/market/common_sections/tables/outcome_table/index.tsx
@@ -124,6 +124,7 @@ export const OutcomeTable = (props: Props) => {
 
   const TableCellsAlign = ['left', 'left', 'right', 'right', 'right', 'right', 'right']
   const symbol = useSymbol(collateral)
+  const bondCollateral = relay ? 'DAI' : 'ETH'
   const renderTableHeader = () => {
     return (
       <THead>
@@ -136,8 +137,8 @@ export const OutcomeTable = (props: Props) => {
                 style={isBond && index === 1 ? { width: '53%' } : {}}
                 textAlign={TableCellsAlign[index]}
               >
-                {value} {value === OutcomeTableValue.CurrentPrice && `(${symbol})`}
-                {value === OutcomeTableValue.Bonded && `(${symbol})`}
+                {value} {value === OutcomeTableValue.CurrentPrice && `(${bondCollateral})`}
+                {value === OutcomeTableValue.Bonded && `(${bondCollateral})`}
               </THStyled>
             ) : null
           })}

--- a/app/src/components/market/common_sections/tables/outcome_table/index.tsx
+++ b/app/src/components/market/common_sections/tables/outcome_table/index.tsx
@@ -137,7 +137,7 @@ export const OutcomeTable = (props: Props) => {
                 style={isBond && index === 1 ? { width: '53%' } : {}}
                 textAlign={TableCellsAlign[index]}
               >
-                {value} {value === OutcomeTableValue.CurrentPrice && `(${bondCollateral})`}
+                {value} {value === OutcomeTableValue.CurrentPrice && `(${symbol})`}
                 {value === OutcomeTableValue.Bonded && `(${bondCollateral})`}
               </THStyled>
             ) : null


### PR DESCRIPTION
closes #2192

The `Bonded` header of the Outcome Table was set on the Symbol of the collateral question while we want it to be set to the native asset of the chain