### PR TITLE
Fix: Fixed dynamic text for set allowance button

### DIFF
--- a/app/src/components/market/common_sections/allowance/set_allowance/index.tsx
+++ b/app/src/components/market/common_sections/allowance/set_allowance/index.tsx
@@ -53,7 +53,7 @@ export const SetAllowance: React.FC<SetAllowanceProps> = (props: SetAllowancePro
                 collateral.symbol}. This has to be done for each new token.`
             : `A new version of the Omen account smart contract is available. Upgrade your Omen account now.`}
         </Description>
-        <ToggleTokenLock finished={finished} loading={loading} onUnlock={onUnlock} />
+        <ToggleTokenLock collateral={collateral} finished={finished} loading={loading} onUnlock={onUnlock} />
       </DescriptionWrapper>
     </Wrapper>
   )

--- a/app/src/components/market/common_sections/allowance/toggle_token_lock/index.tsx
+++ b/app/src/components/market/common_sections/allowance/toggle_token_lock/index.tsx
@@ -11,12 +11,12 @@ export interface ToggleTokenLockProps {
 }
 
 export const ToggleTokenLock = (props: ToggleTokenLockProps) => {
-  const { collateral, finished, loading, onUnlock, ...restProps } = props
+  const { collateral, finished, loading, onUnlock } = props
 
   const state = loading ? ButtonStates.working : finished ? ButtonStates.finished : ButtonStates.idle
 
   return (
-    <ButtonStateful disabled={loading || finished} onClick={onUnlock} state={state} {...restProps}>
+    <ButtonStateful disabled={loading || finished} onClick={onUnlock} state={state}>
       {collateral ? 'Set' : 'Upgrade'}
     </ButtonStateful>
   )

--- a/app/src/components/market/common_sections/allowance/toggle_token_lock/index.tsx
+++ b/app/src/components/market/common_sections/allowance/toggle_token_lock/index.tsx
@@ -1,21 +1,23 @@
 import React from 'react'
 
+import { Token } from '../../../../../util/types'
 import { ButtonStateful, ButtonStates } from '../../../../button/button_stateful'
 
 export interface ToggleTokenLockProps {
+  collateral?: Token
   onUnlock?: any
   loading: boolean
   finished: boolean
 }
 
 export const ToggleTokenLock = (props: ToggleTokenLockProps) => {
-  const { finished, loading, onUnlock } = props
+  const { collateral, finished, loading, onUnlock, ...restProps } = props
 
   const state = loading ? ButtonStates.working : finished ? ButtonStates.finished : ButtonStates.idle
 
   return (
-    <ButtonStateful disabled={loading || finished} onClick={onUnlock} state={state}>
-      Upgrade
+    <ButtonStateful disabled={loading || finished} onClick={onUnlock} state={state} {...restProps}>
+      {collateral ? 'Set' : 'Upgrade'}
     </ButtonStateful>
   )
 }


### PR DESCRIPTION
closes #2191

On a previous PR we set the button to static 'Upgrade'. Here we make it dynamic to show Set vs Upgrade

Testing
- [ ]  Set allowance component uses Set Button
- [ ]  Omen Account Upgrade uses Upgrade Button